### PR TITLE
Fixed Blank If Zero

### DIFF
--- a/build/SetEnv.cmd
+++ b/build/SetEnv.cmd
@@ -1,24 +1,15 @@
 @ECHO OFF
-:: First check for Visual Studio 2019 Professional and, if it's present, use that version
-SET VisualStudioDir=%ProgramFiles%\Microsoft Visual Studio\2022\Community
-IF EXIST "%VisualStudioDir%" GOTO VisualStudio2022
-
-:: Next check for Visual Studio 2019 Enterprise and, if it's present, use that version
-SET VisualStudioDir=%ProgramFiles(x86)%\Microsoft Visual Studio\2022\Community
-IF EXIST "%VisualStudioDir%" GOTO VisualStudio2019
-
-:: Next check for Visual Studio 2019 Build Tools and, If not present, exit.
-SET VisualStudioDir=%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools
-IF EXIST "%VisualStudioDir%" GOTO VisualStudio2019
-
-IF NOT EXIST "%VisualStudioDir%" (
-  ECHO Failed to establish VS2022 build environment
-  GOTO End
-)
+:: To best mimic github builds use the VS2022 build tools
+SET VisualStudioDir="C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools"
+IF EXIST %VisualStudioDir% GOTO VisualStudio2022
+ECHO Failed to find VS2022 build environment
+ECHO Visit https://visualstudio.microsoft.com/downloads/
+ECHO to install the VS2022 build tools. 
+GOTO End
 
 :VisualStudio2022
-ECHO Establishing VS 2022 build environment using: %VisualStudioDir%
-CALL "%VisualStudioDir%\VC\Auxiliary\Build\vcvarsall.bat" x86 10.0.22621.755 -vcvars_ver=14.3
+ECHO Establishing VS 2022 build environment
+%VisualStudioDir%\Common7\Tools\VsMSBuildCmd.bat
 SET VisualStudioDir=
 
 :CloseOut

--- a/src/Impl/BaseTable.cs
+++ b/src/Impl/BaseTable.cs
@@ -1,6 +1,7 @@
 ﻿using Contract;
 using System;
 using System.Data;
+using System.Drawing;
 using System.IO;
 using Excel = Microsoft.Office.Interop.Excel;
 
@@ -269,7 +270,7 @@ namespace Impl
                            Operator: Excel.XlFormatConditionOperator.xlEqual,
                            Formula1: "=0");
 
-                        //fc.Font.Color = System.Drawing.ColorTranslator.ToOle(System.Drawing.Color.White);
+                        fc.Font.Color = System.Drawing.ColorTranslator.ToOle(System.Drawing.Color.White);
                     }
 
 

--- a/src/Impl/Impl.csproj
+++ b/src/Impl/Impl.csproj
@@ -33,6 +33,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />


### PR DESCRIPTION
Fixed the BaseTable.cs so if the class has specified blankifzero the spreadsheet shows a blank instead of a zero-is-blank Also fixed SetEnv.cmd so it properly sets the msbuild environment from the command line.