### PR TITLE
Search for log files in the SubFolder

### DIFF
--- a/src/CashIn/CashInTable.cs
+++ b/src/CashIn/CashInTable.cs
@@ -255,14 +255,14 @@ namespace CashIn
 
                for (int i = 0; i < _currentValues.Length; i++)
                {
-                  //if (_currentValues[i] == currentValues[i])
-                  //{
-                  //   dataRow[_columnNamesArray[i]] = string.Empty;
-                  //}
-                  //else
-                  //{
+                  if (_currentValues[i] == currentValues[i])
+                  {
+                     dataRow[_columnNamesArray[i]] = string.Empty;
+                  }
+                  else
+                  {
                      dataRow[_columnNamesArray[i]] = currentValues[i];
-                  //}
+                  }
                }
 
                dTable.Rows.Add(dataRow);

--- a/src/Impl/Utilities.cs
+++ b/src/Impl/Utilities.cs
@@ -84,7 +84,7 @@ namespace Impl
          ctx.ConsoleWriteLogLine("Unzip complete.");
 
          // find all nwlog files
-         string[] tempFiles = ctx.ioProvider.GetFiles(ctx.WorkFolder, "*.nwlog");
+         string[] tempFiles = ctx.ioProvider.GetFiles(ctx.WorkFolder + "\\" + ctx.SubFolder, "*.nwlog");
 
          // reduce to nwlog files in the [SP] subfolder, if any
          List<string> tempList = new List<string>();


### PR DESCRIPTION
Changed the log file search so that it starts in the subfolder. This prevents finding log files from other zip files in other folders. Updated the Cashin table so it blanks out values from 'this' row already reported in the previous row. Cleaner presentatation of data. Dont report something that hasnt changed.