### PR TITLE
Added 'initial' to cash units for better information. 

### DIFF
--- a/src/CDMView/CDMView.xsd
+++ b/src/CDMView/CDMView.xsd
@@ -38,7 +38,7 @@
               <xs:element name="LU7" type="xs:string" minOccurs="0" />
               <xs:element name="LU8" type="xs:string" minOccurs="0" />
               <xs:element name="LU9" type="xs:string" minOccurs="0" />
-              <xs:element name="comment" type="xs:string" minOccurs="0" />			  
+              <xs:element name="comment" type="xs:string" minOccurs="0" />
             </xs:sequence>
           </xs:complexType>
         </xs:element>
@@ -60,15 +60,6 @@
             </xs:sequence>
           </xs:complexType>
         </xs:element>
-        <xs:element name="CashUnit">
-          <xs:complexType>
-            <xs:sequence>
-              <xs:element name="file" type="xs:string" minOccurs="0" />
-              <xs:element name="time" type="xs:string" minOccurs="0" />
-              <xs:element name="error" type="xs:string" minOccurs="0" />
-            </xs:sequence>
-          </xs:complexType>
-        </xs:element>
         <xs:element name="CashUnit-1">
           <xs:complexType>
             <xs:sequence>
@@ -76,12 +67,13 @@
               <xs:element name="time" type="xs:string" minOccurs="0" />
               <xs:element name="error" type="xs:string" minOccurs="0" />
               <xs:element name="status" type="xs:string" minOccurs="0" />
+              <xs:element name="initial" type="xs:string" minOccurs="0" />
               <xs:element name="count" type="xs:string" minOccurs="0" />
               <xs:element name="reject" type="xs:string" minOccurs="0" />
               <xs:element name="dispensed" type="xs:string" minOccurs="0" />
               <xs:element name="presented" type="xs:string" minOccurs="0" />
               <xs:element name="retracted" type="xs:string" minOccurs="0" />
-              <xs:element name="comment" type="xs:string" minOccurs="0" />			  
+              <xs:element name="comment" type="xs:string" minOccurs="0" />
             </xs:sequence>
           </xs:complexType>
         </xs:element>
@@ -92,6 +84,7 @@
               <xs:element name="time" type="xs:string" minOccurs="0" />
               <xs:element name="error" type="xs:string" minOccurs="0" />
               <xs:element name="status" type="xs:string" minOccurs="0" />
+              <xs:element name="initial" type="xs:string" minOccurs="0" />
               <xs:element name="count" type="xs:string" minOccurs="0" />
               <xs:element name="reject" type="xs:string" minOccurs="0" />
               <xs:element name="dispensed" type="xs:string" minOccurs="0" />
@@ -108,6 +101,7 @@
               <xs:element name="time" type="xs:string" minOccurs="0" />
               <xs:element name="error" type="xs:string" minOccurs="0" />
               <xs:element name="status" type="xs:string" minOccurs="0" />
+              <xs:element name="initial" type="xs:string" minOccurs="0" />
               <xs:element name="count" type="xs:string" minOccurs="0" />
               <xs:element name="reject" type="xs:string" minOccurs="0" />
               <xs:element name="dispensed" type="xs:string" minOccurs="0" />
@@ -124,6 +118,7 @@
               <xs:element name="time" type="xs:string" minOccurs="0" />
               <xs:element name="error" type="xs:string" minOccurs="0" />
               <xs:element name="status" type="xs:string" minOccurs="0" />
+              <xs:element name="initial" type="xs:string" minOccurs="0" />
               <xs:element name="count" type="xs:string" minOccurs="0" />
               <xs:element name="reject" type="xs:string" minOccurs="0" />
               <xs:element name="dispensed" type="xs:string" minOccurs="0" />
@@ -140,6 +135,7 @@
               <xs:element name="time" type="xs:string" minOccurs="0" />
               <xs:element name="error" type="xs:string" minOccurs="0" />
               <xs:element name="status" type="xs:string" minOccurs="0" />
+              <xs:element name="initial" type="xs:string" minOccurs="0" />
               <xs:element name="count" type="xs:string" minOccurs="0" />
               <xs:element name="reject" type="xs:string" minOccurs="0" />
               <xs:element name="dispensed" type="xs:string" minOccurs="0" />
@@ -156,6 +152,58 @@
               <xs:element name="time" type="xs:string" minOccurs="0" />
               <xs:element name="error" type="xs:string" minOccurs="0" />
               <xs:element name="status" type="xs:string" minOccurs="0" />
+              <xs:element name="initial" type="xs:string" minOccurs="0" />
+              <xs:element name="count" type="xs:string" minOccurs="0" />
+              <xs:element name="reject" type="xs:string" minOccurs="0" />
+              <xs:element name="dispensed" type="xs:string" minOccurs="0" />
+              <xs:element name="presented" type="xs:string" minOccurs="0" />
+              <xs:element name="retracted" type="xs:string" minOccurs="0" />
+              <xs:element name="comment" type="xs:string" minOccurs="0" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="CashUnit-7">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="file" type="xs:string" minOccurs="0" />
+              <xs:element name="time" type="xs:string" minOccurs="0" />
+              <xs:element name="error" type="xs:string" minOccurs="0" />
+              <xs:element name="status" type="xs:string" minOccurs="0" />
+              <xs:element name="initial" type="xs:string" minOccurs="0" />
+              <xs:element name="count" type="xs:string" minOccurs="0" />
+              <xs:element name="reject" type="xs:string" minOccurs="0" />
+              <xs:element name="dispensed" type="xs:string" minOccurs="0" />
+              <xs:element name="presented" type="xs:string" minOccurs="0" />
+              <xs:element name="retracted" type="xs:string" minOccurs="0" />
+              <xs:element name="comment" type="xs:string" minOccurs="0" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="CashUnit-8">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="file" type="xs:string" minOccurs="0" />
+              <xs:element name="time" type="xs:string" minOccurs="0" />
+              <xs:element name="error" type="xs:string" minOccurs="0" />
+              <xs:element name="status" type="xs:string" minOccurs="0" />
+              <xs:element name="initial" type="xs:string" minOccurs="0" />
+              <xs:element name="count" type="xs:string" minOccurs="0" />
+              <xs:element name="reject" type="xs:string" minOccurs="0" />
+              <xs:element name="dispensed" type="xs:string" minOccurs="0" />
+              <xs:element name="presented" type="xs:string" minOccurs="0" />
+              <xs:element name="retracted" type="xs:string" minOccurs="0" />
+              <xs:element name="comment" type="xs:string" minOccurs="0" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="CashUnit-9">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="file" type="xs:string" minOccurs="0" />
+              <xs:element name="time" type="xs:string" minOccurs="0" />
+              <xs:element name="error" type="xs:string" minOccurs="0" />
+              <xs:element name="status" type="xs:string" minOccurs="0" />
+              <xs:element name="initial" type="xs:string" minOccurs="0" />
               <xs:element name="count" type="xs:string" minOccurs="0" />
               <xs:element name="reject" type="xs:string" minOccurs="0" />
               <xs:element name="dispensed" type="xs:string" minOccurs="0" />

--- a/src/Impl/IdentifyLines.cs
+++ b/src/Impl/IdentifyLines.cs
@@ -139,52 +139,52 @@ namespace Impl
          if (logLine.Contains("GETINFO[3") || logLine.Contains("EXECUTE[3") || logLine.Contains("SERVICE_EVENT[3"))
          {
             /* INFO */
-            Regex wfs_inf_cdm_status = new Regex("GETINFO.301.[0-9]+WFS_GETINFO_COMPLETE");
-            Regex wfs_inf_cdm_cash_unit_info = new Regex("GETINFO.303.[0-9]+WFS_GETINFO_COMPLETE");
+            Regex WFS_INF_CDM_STATUS = new Regex("GETINFO.301.[0-9]+WFS_GETINFO_COMPLETE");
+            Regex WFS_INF_CDM_CASH_UNIT_INFO = new Regex("GETINFO.303.[0-9]+WFS_GETINFO_COMPLETE");
             Regex WFS_INF_CDM_PRESENT_STATUS = new Regex("GETINFO.309.[0-9]+WFS_GETINFO_COMPLETE");
 
             /* EXECUTE */
-            Regex wfs_cmd_cdm_dispense = new Regex("EXECUTE.302.[0-9]+WFS_EXECUTE_COMPLETE");
-            Regex wfs_cmd_cdm_present = new Regex("EXECUTE.303.[0-9]+WFS_EXECUTE_COMPLETE");
-            Regex wfs_cmd_cdm_reject = new Regex("EXECUTE.304.[0-9]+WFS_EXECUTE_COMPLETE");
-            Regex wfs_cmd_cdm_retract = new Regex("EXECUTE.305.[0-9]+WFS_EXECUTE_COMPLETE");
-            Regex wfs_cmd_cdm_reset = new Regex("EXECUTE.321.[0-9]+WFS_EXECUTE_COMPLETE");
+            Regex WFS_CMD_CDM_DISPENSE = new Regex("EXECUTE.302.[0-9]+WFS_EXECUTE_COMPLETE");
+            Regex WFS_CMD_CDM_PRESENT = new Regex("EXECUTE.303.[0-9]+WFS_EXECUTE_COMPLETE");
+            Regex WFS_CMD_CDM_REJECT = new Regex("EXECUTE.304.[0-9]+WFS_EXECUTE_COMPLETE");
+            Regex WFS_CMD_CDM_RETRACT = new Regex("EXECUTE.305.[0-9]+WFS_EXECUTE_COMPLETE");
+            Regex WFS_CMD_CDM_RESET = new Regex("EXECUTE.321.[0-9]+WFS_EXECUTE_COMPLETE");
 
             /* EVENTS */
-            Regex wfs_srve_cdm_cashunitinfochanged = new Regex("SERVICE_EVENT.304.[0-9]+WFS_SERVICE_EVENT");
-            Regex wfs_srve_cdm_itemstaken = new Regex("SERVICE_EVENT.309.[0-9]+WFS_SERVICE_EVENT");
+            Regex WFS_SRVE_CDM_CASHUNITINFOCHANGED = new Regex("SERVICE_EVENT.304.[0-9]+WFS_SERVICE_EVENT");
+            Regex WFS_SRVE_CDM_ITEMSTAKEN = new Regex("SERVICE_EVENT.309.[0-9]+WFS_SERVICE_EVENT");
 
             /* Test for INFO */
-            result = GenericMatch(wfs_inf_cdm_status, logLine);
+            result = GenericMatch(WFS_INF_CDM_STATUS, logLine);
             if (result.success) return (XFSType.WFS_INF_CDM_STATUS, result.xfsLine);
 
-            result = GenericMatch(wfs_inf_cdm_cash_unit_info, logLine);
+            result = GenericMatch(WFS_INF_CDM_CASH_UNIT_INFO, logLine);
             if (result.success) return (XFSType.WFS_INF_CDM_CASH_UNIT_INFO, result.xfsLine);
 
             result = GenericMatch(WFS_INF_CDM_PRESENT_STATUS, logLine);
             if (result.success) return (XFSType.WFS_INF_CDM_PRESENT_STATUS, result.xfsLine);
 
             /* Test for EXECUTE */
-            result = GenericMatch(wfs_cmd_cdm_dispense, logLine);
+            result = GenericMatch(WFS_CMD_CDM_DISPENSE, logLine);
             if (result.success) return (XFSType.WFS_CMD_CDM_DISPENSE, result.xfsLine);
 
-            result = GenericMatch(wfs_cmd_cdm_present, logLine);
+            result = GenericMatch(WFS_CMD_CDM_PRESENT, logLine);
             if (result.success) return (XFSType.WFS_CMD_CDM_PRESENT, result.xfsLine);
 
-            result = GenericMatch(wfs_cmd_cdm_reject, logLine);
+            result = GenericMatch(WFS_CMD_CDM_REJECT, logLine);
             if (result.success) return (XFSType.WFS_CMD_CDM_REJECT, result.xfsLine);
 
-            result = GenericMatch(wfs_cmd_cdm_retract, logLine);
+            result = GenericMatch(WFS_CMD_CDM_RETRACT, logLine);
             if (result.success) return (XFSType.WFS_CMD_CDM_RETRACT, result.xfsLine);
 
-            result = GenericMatch(wfs_cmd_cdm_reset, logLine);
+            result = GenericMatch(WFS_CMD_CDM_RESET, logLine);
             if (result.success) return (XFSType.WFS_CMD_CDM_RESET, result.xfsLine);
 
             /* Test for EVENTS */
-            result = GenericMatch(wfs_srve_cdm_cashunitinfochanged, logLine);
+            result = GenericMatch(WFS_SRVE_CDM_CASHUNITINFOCHANGED, logLine);
             if (result.success) return (XFSType.WFS_SRVE_CDM_CASHUNITINFOCHANGED, result.xfsLine);
 
-            result = GenericMatch(wfs_srve_cdm_itemstaken, logLine);
+            result = GenericMatch(WFS_SRVE_CDM_ITEMSTAKEN, logLine);
             if (result.success) return (XFSType.WFS_SRVE_CDM_ITEMSTAKEN, result.xfsLine);
 
             /* We should have matched something */


### PR DESCRIPTION
Also did some house-keeping.

Removed the has_seen_WFS_INF_CDM_CASH_UNIT_INFO variable Added try/catch blocks around table compression etc. Capitalized CDM variables in IdentifyLines.cs
Increased the number of default cash units to 9.