### PR TITLE
Bug: Fix timestamps so Excel can do timestamp math

### DIFF
--- a/src/Impl/BaseTable.cs
+++ b/src/Impl/BaseTable.cs
@@ -438,9 +438,9 @@ namespace Impl
                {
                   // set format for date/time column to be readable
                   Console.WriteLine("Set the formula for the date/time column...");
-                  Microsoft.Office.Interop.Excel.Range timeColumn = activeSheet.Range[activeSheet.Cells[rowOffset, 1], activeSheet.Cells[dataView.Count + 1, 1]];
-                  timeColumn.Cells.NumberFormat = "YYYY-MM-ddTHH:mm:ss.000";
-                  timeColumn.Cells.ColumnWidth = 20;
+                  Microsoft.Office.Interop.Excel.Range timeColumn = activeSheet.Range[activeSheet.Cells[rowOffset, 2], activeSheet.Cells[dataView.Count + 1, 2]];
+                  timeColumn.Cells.NumberFormat = "yyyy-mm-dd hh:mm:ss.000";
+                  timeColumn.Cells.ColumnWidth = 21;
 
                   // copy the 2D data array into the excel worksheet starting at rowOffset, colOffset
                   Microsoft.Office.Interop.Excel.Range dispenseRange = activeSheet.Range[activeSheet.Cells[rowOffset, colOffset], activeSheet.Cells[dataView.Count + rowOffset - 1, colCount + colOffset - 1]];

--- a/src/Impl/lpResult.cs
+++ b/src/Impl/lpResult.cs
@@ -6,6 +6,8 @@ namespace Impl
    {
       public static string tsTimestamp(string logLine)
       {
+         // the string from the log file, but return is in normal form
+         // (replace '/' with '-' and the 2nd space with a ':')
          string logTime = "2022/01/01 00:00 00.000";
 
          // Example: tsTimestamp = [2023/02/01 21:03 11.557],
@@ -14,6 +16,17 @@ namespace Impl
          if (mtch.Success)
          {
             logTime = mtch.Groups[1].Value;
+         }
+
+         // replace / with -
+         logTime = logTime.Replace('/', '-');
+
+         // replace the 17th character (' ' with ':')
+         char replacementChar = ':';
+
+         if (logTime.Length >= 17)
+         {
+            logTime = logTime.Remove(16, 1).Insert(16, replacementChar.ToString());
          }
 
          return logTime;

--- a/src/ImplTests/lpResultTests.cs
+++ b/src/ImplTests/lpResultTests.cs
@@ -10,20 +10,10 @@ namespace SPLogParserTests
       [TestMethod]
       public void GetlpResultTime()
       {
-         string lpResultLine = @"
-            lpResult =
-            {
-	            hWnd = [0x000100dc],
-	            RequestID = [60984],
-	            hService = [10],
-	            tsTimestamp = [2023/02/01 21:03 11.557],
-	            hResult = [0],
-	            u.dwCommandCode = [302],
-	            lpBuffer = [0x12416bec]
-            ";
-
-         string logTime = lpResult.tsTimestamp(lpResultLine);
-         Assert.IsTrue(logTime.Equals("2023/02/01 21:03 11.557"));
+         string xfsLine = Samples.samples_general.WFS_INF_PTR_STATUS;
+         (XFSType xfsType, string xfsLine) result = IdentifyLines.XFSLine(xfsLine);
+         string logTime = lpResult.tsTimestamp(result.xfsLine);
+         Assert.IsTrue(logTime.Equals("2023-03-17 08:42:28.033"));
       }
 
       [TestMethod]
@@ -43,7 +33,25 @@ namespace SPLogParserTests
             ";
 
          string logTime = lpResult.tsTimestamp(lpResultLine);
-         Assert.IsTrue(logTime.Equals("2023/02/01 21:03 11.557"));
+         Assert.IsTrue(logTime.Equals("2023-02-01 21:03:11.557"));
+      }
+
+      [TestMethod]
+      public void GetDefaultlpResultTime()
+      {
+         string lpResultLine = @"
+            lpResult =
+            {
+	            hWnd = [0x000100dc],
+	            RequestID = [60984],
+	            hService = [10],
+	            hResult = [-123],
+	            u.dwCommandCode = [302],
+	            lpBuffer = [0x12416bec]
+            ";
+
+         string logTime = lpResult.tsTimestamp(lpResultLine);
+         Assert.IsTrue(logTime.Equals("2022-01-01 00:00:00.000"));
       }
 
       [TestMethod]
@@ -62,8 +70,8 @@ namespace SPLogParserTests
 	            tsTimestamp = [2023/02/01 00:00 00.000],
             ";
 
-         string logTime = lpResult.hResult(lpResultLine);
-         Assert.IsTrue(logTime.Equals("-123"));
+         string hResult = lpResult.hResult(lpResultLine);
+         Assert.IsTrue(hResult.Equals("-123"));
       }
 
       [TestMethod]
@@ -82,8 +90,8 @@ namespace SPLogParserTests
 	            tsTimestamp = [2023/02/01 00:00 00.000],
             ";
 
-         string logTime = lpResult.hResult(lpResultLine);
-         Assert.IsTrue(logTime.Equals(""));
+         string hResult = lpResult.hResult(lpResultLine);
+         Assert.IsTrue(hResult.Equals(""));
       }
    }
 }

--- a/src/WFSTests/WFSCDMCUINFOTests.cs
+++ b/src/WFSTests/WFSCDMCUINFOTests.cs
@@ -22,7 +22,7 @@ namespace SPLogParserTests
       public void TestTimestamp()
       {
          string timeStamp = lpResult.tsTimestamp(xfsLineTable);
-         Assert.IsTrue(timeStamp == "2022/12/19 16:01 26.018");
+         Assert.IsTrue(timeStamp == "2022-12-19 16:01:26.018");
 
       }
       [TestMethod]

--- a/src/WFSTests/WFSCIMCASHINFOTests.cs
+++ b/src/WFSTests/WFSCIMCASHINFOTests.cs
@@ -373,10 +373,10 @@ lpResult =
       public void TestTimestamp()
       {
          string timeStamp = lpResult.tsTimestamp(xfsLineTable);
-         Assert.IsTrue(timeStamp == "2023/01/24 00:59 14.660");
+         Assert.IsTrue(timeStamp == "2023-01-24 00:59:14.660");
 
          timeStamp = lpResult.tsTimestamp(xfsLineList);
-         Assert.IsTrue(timeStamp == "2023/03/15 17:54 56.723");
+         Assert.IsTrue(timeStamp == "2023-03-15 17:54:56.723");
 
       }
       [TestMethod]


### PR DESCRIPTION
I discovered that Excel can't do timestamp math. The reason is the format of time being stored was wrong (space between minute and second). Changed lpResult.cs to return a well formed timestamp. Correct some unit tests give the change. Updated timestamp formatting in BaseTable.cs