### PR TITLE
fix: Added column 'comment' to the Decision to Compress

### DIFF
--- a/src/ExtraView/ExtraTable.cs
+++ b/src/ExtraView/ExtraTable.cs
@@ -140,7 +140,7 @@ namespace ExtraView
             tableName = "Status";
 
             // COMPRESS
-            string[] columns = new string[] { "error", "device", "spver", "epver" };
+            string[] columns = new string[] { "error", "device", "spver", "epver", "comment" };
             RemoveDuplicateRows(tableName, columns);
          }
          catch (Exception e)


### PR DESCRIPTION
Added the column 'comment' to the list of columns used when deciding to compress. I did this so ErrorCode changes would not be lost.