### PR TITLE
Fix: Add Cash Dispense View

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Combine one or more *Parse Type* with one or more *View* to tell the parse what 
 
 | View     | Description |
 |----------|----------------------|
+| Disp     | Cash Dispense |
 | EJ       | EJ Insert commands            |
 | XmlParam | Config files and their parameters in table form |
 | AddKey   | Keys loaded on start-up |
@@ -125,7 +126,6 @@ Show me all [AP] views and from the [SP] logs the Dispense operations.
 ```text
 splogparser -a * -s CDM -f 20221116175903.zip
 ```
-
 
 
 ## Known Issues

--- a/src/APLine/APLine.cs
+++ b/src/APLine/APLine.cs
@@ -42,11 +42,9 @@ namespace LogLineHandler
       PINPAD,
 
 
-      /* CASH DISPENSER */ 
+      /* CASH DISPENSER */
 
       CashDispenser_Open,
-
-
 
       /* STATUS */
 
@@ -60,7 +58,7 @@ namespace LogLineHandler
 
       /* position status */
 
-      CashDispenser_NotInPosition, 
+      CashDispenser_NotInPosition,
       CashDispenser_InPosition,
 
 
@@ -84,6 +82,11 @@ namespace LogLineHandler
       CashDispenser_OnTransportEmpty,
       CashDispenser_OnCashUnitChanged,
 
+      /* NDC */
+      NDC,
+      Atm2Host11,
+      Host2Atm1,
+
 
       /* SUMMARY */
 
@@ -103,7 +106,18 @@ namespace LogLineHandler
       CashDispenser_OnRetractComplete,
       CashDispenser_OnItemsTaken,
       CashDispenser_GetLCULastDispensedCount,
+      CashDispenser_UpdateTypeInfoToDispense,
 
+      /* CORE */
+      Core_ProcessWithdrawalTransaction_Account,
+      Core_ProcessWithdrawalTransaction_Amount,
+      Core_DispensedAmount,
+      Core_RequiredBillMixList,
+
+      /* HELPER FUNCTIONS */
+      HelperFunctions,
+      HelperFunctions_GetConfiguredBillMixList,
+      HelperFunctions_GetFewestBillMixList,
 
       SYMX_DISPENSE,
 
@@ -199,7 +213,7 @@ namespace LogLineHandler
             }
          }
 
-         return timestamp; 
+         return timestamp;
       }
    }
 }

--- a/src/APLine/CashDispenser/CashDispener.cs
+++ b/src/APLine/CashDispenser/CashDispener.cs
@@ -4,15 +4,12 @@ namespace LogLineHandler
 {
    public class CashDispenser
    {
-
       public static ILogLine Factory(ILogFileHandler logFileHandler, string logLine)
       {
          /* CASH DISPENSER */
 
          if (logLine.Contains("[CashDispenser") && logLine.Contains("[Open") && logLine.Contains("NumberOfPhysicalUnits"))
             return new CashDispenser_Open(logFileHandler, logLine);
-
-
 
          /* STATUS */
 
@@ -117,9 +114,12 @@ namespace LogLineHandler
             return new APLine(logFileHandler, logLine, APLogType.CashDispenser_OnItemsTaken);
 
          if (logLine.Contains("[CashDispenser") && logLine.Contains("[GetLCULastDispensedCount"))
-            return new APLine(logFileHandler, logLine, APLogType.CashDispenser_OnItemsTaken);
+            return new CashDispenser_GetLCULastDispensedCount(logFileHandler, logLine);
 
-         return null; 
+         if (logLine.Contains("[CashDispenser") && logLine.Contains("[UpdateTypeInfoToDispense"))
+            return new CashDispenser_UpdateTypeInfoToDispense(logFileHandler, logLine);
+
+         return null;
       }
    }
 }

--- a/src/APLine/CashDispenser/CashDispenser_GetLCULastDispensedCount.cs
+++ b/src/APLine/CashDispenser/CashDispenser_GetLCULastDispensedCount.cs
@@ -23,7 +23,8 @@ namespace LogLineHandler
          int idx = logLine.IndexOf(findMe);
          if (idx != -1)
          {
-            string[] terms = logLine.Substring(idx + findMe.Length + 1).Replace(" ","").Split('=');
+            string subLogLine = logLine.Substring(idx + findMe.Length);
+            string[] terms = subLogLine.Replace(" ", "").Split('=');
             noteType = terms[0];
             amount = terms[1].Trim();
          }

--- a/src/APLine/CashDispenser/CashDispenser_SetupCSTList.cs
+++ b/src/APLine/CashDispenser/CashDispenser_SetupCSTList.cs
@@ -27,7 +27,7 @@ namespace LogLineHandler
                relation = "1:" + terms[0];
                parent = terms[2];
                child = terms[5].Trim(); ;
-            }   
+            }
          }
       }
    }

--- a/src/APLine/CashDispenser/CashDispenser_SetupNoteType.cs
+++ b/src/APLine/CashDispenser/CashDispenser_SetupNoteType.cs
@@ -38,7 +38,7 @@ namespace LogLineHandler
 
             noteType = m.Groups["notetype"].Value;
             currency = m.Groups["currency"].Value;
-            value = m.Groups["value"].Value; 
+            value = m.Groups["value"].Value;
             splcu = m.Groups["splcu"].Value;
             sppcu = m.Groups["sppcu"].Value;
          }

--- a/src/APLine/CashDispenser/CashDispenser_UpdateTypeInfoToDispense.cs
+++ b/src/APLine/CashDispenser/CashDispenser_UpdateTypeInfoToDispense.cs
@@ -1,0 +1,28 @@
+﻿using System.Text.RegularExpressions;
+using Contract;
+
+namespace LogLineHandler
+{
+   public class CashDispenser_UpdateTypeInfoToDispense : APLine
+   {
+      public string dispenseAmount;
+
+      public CashDispenser_UpdateTypeInfoToDispense(ILogFileHandler parent, string logLine, APLogType apType = APLogType.CashDispenser_UpdateTypeInfoToDispense) : base(parent, logLine, apType)
+      {
+      }
+
+      protected override void Initialize()
+      {
+         base.Initialize();
+
+         string findMe = "Dispensing amount in total is ";
+
+         int idx = logLine.IndexOf(findMe);
+         if (idx != -1)
+         {
+            dispenseAmount = logLine.Substring(idx + findMe.Length).Trim();
+         }
+      }
+
+   }
+}

--- a/src/APLine/Core/Core.cs
+++ b/src/APLine/Core/Core.cs
@@ -1,0 +1,48 @@
+﻿using System.Text.RegularExpressions;
+using Contract;
+
+namespace LogLineHandler
+{
+   public class Core : APLine
+   {
+      public string name;
+
+      public Core(ILogFileHandler parent, string logLine, APLogType apType) : base(parent, logLine, apType)
+      {
+      }
+
+      protected override void Initialize()
+      {
+         base.Initialize();
+
+         name = string.Empty;
+
+         // e.g. [KeyBridgeWebServiceRequestFlowPoint]
+         Regex regex = new Regex("^.*\\[(?<corename>.*?)WebServiceRequestFlowPoint.*$");
+         Match m = regex.Match(logLine);
+         if (m.Success)
+         {
+            name = m.Groups["corename"].Value;
+         }
+      }
+
+      public static ILogLine Factory(ILogFileHandler logFileHandler, string logLine)
+      {
+         /* CORE  - WebServiceRequestFlowPoint */
+
+         if (logLine.Contains("WebServiceRequestFlowPoint") && logLine.Contains("[ProcessWithdrawalTransaction") && logLine.Contains("Amount"))
+            return new Core_ProcessWithdrawalTransactionAmount(logFileHandler, logLine);
+
+         if (logLine.Contains("WebServiceRequestFlowPoint") && logLine.Contains("[ProcessWithdrawalTransaction") && logLine.Contains("Account"))
+            return new Core_ProcessWithdrawalTransactionAccount(logFileHandler, logLine);
+
+         if (logLine.Contains("WebServiceRequestFlowPoint") && logLine.Contains("[DispenseCurrency") && logLine.Contains("RequiredBillMixList"))
+            return new Core_RequiredBillMixList(logFileHandler, logLine);
+
+         if (logLine.Contains("WebServiceRequestFlowPoint") && logLine.Contains("[DispenseCurrency") && logLine.Contains("dispensedAmount"))
+            return new Core_DispensedAmount(logFileHandler, logLine);
+
+         return null;
+      }
+   }
+}

--- a/src/APLine/Core/Core_DispensedAmount.cs
+++ b/src/APLine/Core/Core_DispensedAmount.cs
@@ -1,0 +1,24 @@
+﻿using Contract;
+
+namespace LogLineHandler
+{
+   public class Core_DispensedAmount : Core
+   {
+      public string amount;
+
+      public Core_DispensedAmount(ILogFileHandler parent, string logLine, APLogType apType = APLogType.Core_DispensedAmount) : base(parent, logLine, apType)
+      {
+      }
+
+      protected override void Initialize()
+      {
+         base.Initialize();
+
+         int idx = logLine.LastIndexOf("=");
+         if (idx != -1)
+         {
+            amount = logLine.Substring(idx + 1).Trim();
+         }
+      }
+   }
+}

--- a/src/APLine/Core/Core_ProcessWithdrawalTransactionAccount.cs
+++ b/src/APLine/Core/Core_ProcessWithdrawalTransactionAccount.cs
@@ -1,0 +1,35 @@
+﻿using Contract;
+
+namespace LogLineHandler
+{
+   public class Core_ProcessWithdrawalTransactionAccount : Core
+   {
+      public string account;
+
+      public Core_ProcessWithdrawalTransactionAccount(ILogFileHandler parent, string logLine, APLogType apType = APLogType.Core_ProcessWithdrawalTransaction_Account) : base(parent, logLine, apType)
+      {
+      }
+
+      protected override void Initialize()
+      {
+         base.Initialize();
+
+         string findMe = "Account Number";
+
+         int idx = logLine.LastIndexOf(findMe);
+         if (idx != -1)
+         {
+            account = logLine.Substring(idx + findMe.Length + 1);
+
+            // JackHenry has a slightly different form e.g. [NORMAL]Account Number - x4361, Account Type - D, Transaction Code - 58
+            idx = account.IndexOf(",");
+            if (idx != -1)
+            {
+               // isolate the account number by skipping over the '-' and truncating on the ','
+               account = account.Substring(2, idx - 2);
+            }
+            account = account.Trim();
+         }
+      }
+   }
+}

--- a/src/APLine/Core/Core_ProcessWithdrawalTransactionAmount.cs
+++ b/src/APLine/Core/Core_ProcessWithdrawalTransactionAmount.cs
@@ -1,0 +1,26 @@
+﻿using Contract;
+
+namespace LogLineHandler
+{
+   public class Core_ProcessWithdrawalTransactionAmount : Core
+   {
+      public string amount;
+
+      public Core_ProcessWithdrawalTransactionAmount(ILogFileHandler parent, string logLine, APLogType apType = APLogType.Core_ProcessWithdrawalTransaction_Amount) : base(parent, logLine, apType)
+      {
+      }
+
+      protected override void Initialize()
+      {
+         base.Initialize();
+
+         string findMe = " ";
+
+         int idx = logLine.LastIndexOf(findMe);
+         if (idx != -1)
+         {
+            amount = logLine.Substring(idx + findMe.Length).Trim();
+         }
+      }
+   }
+}

--- a/src/APLine/Core/Core_RequiredBillMixList.cs
+++ b/src/APLine/Core/Core_RequiredBillMixList.cs
@@ -1,0 +1,26 @@
+﻿using Contract;
+
+namespace LogLineHandler
+{
+   public class Core_RequiredBillMixList : Core
+   {
+      public string requiredbillmixlist;
+
+      public Core_RequiredBillMixList(ILogFileHandler parent, string logLine, APLogType apType = APLogType.Core_RequiredBillMixList) : base(parent, logLine, apType)
+      {
+      }
+
+      protected override void Initialize()
+      {
+         base.Initialize();
+
+         string findMe = ":";
+
+         int idx = logLine.LastIndexOf(findMe);
+         if (idx != -1)
+         {
+            requiredbillmixlist = logLine.Substring(idx + findMe.Length).Trim();
+         }
+      }
+   }
+}

--- a/src/APLine/HelperFunctions/HelperFunctions.cs
+++ b/src/APLine/HelperFunctions/HelperFunctions.cs
@@ -1,0 +1,22 @@
+﻿using Contract;
+
+namespace LogLineHandler
+{
+   public class HelperFunctions : APLine
+   {
+      public HelperFunctions(ILogFileHandler parent, string logLine, APLogType apType) : base(parent, logLine, apType)
+      {
+      }
+
+      public static ILogLine Factory(ILogFileHandler logFileHandler, string logLine)
+      {
+         if (logLine.Contains("[HelperFunctions") && logLine.Contains("[GetConfiguredBillMixList") && logLine.Contains("ConfiguredBillMixList:"))
+            return new HelperFunctions_GetConfiguredBillMixList(logFileHandler, logLine);
+
+         if (logLine.Contains("[HelperFunctions") && logLine.Contains("[GetFewestBillMixList") && logLine.Contains("FewestBillMixList:"))
+            return new HelperFunctions_GetFewestBillMixList(logFileHandler, logLine);
+
+         return null;
+      }
+   }
+}

--- a/src/APLine/HelperFunctions/HelperFunctions_GetConfiguredBillMixList.cs
+++ b/src/APLine/HelperFunctions/HelperFunctions_GetConfiguredBillMixList.cs
@@ -1,0 +1,26 @@
+﻿using Contract;
+
+namespace LogLineHandler
+{
+   public class HelperFunctions_GetConfiguredBillMixList : HelperFunctions
+   {
+      public string configuredbillmixlist;
+
+      public HelperFunctions_GetConfiguredBillMixList(ILogFileHandler parent, string logLine, APLogType apType = APLogType.HelperFunctions_GetConfiguredBillMixList) : base(parent, logLine, apType)
+      {
+      }
+
+      protected override void Initialize()
+      {
+         base.Initialize();
+
+         string findMe = "ConfiguredBillMixList:";
+
+         int idx = logLine.LastIndexOf(findMe);
+         if (idx != -1)
+         {
+            configuredbillmixlist = logLine.Substring(idx + findMe.Length).Trim();
+         }
+      }
+   }
+}

--- a/src/APLine/HelperFunctions/HelperFunctions_GetFewestBillMixList.cs
+++ b/src/APLine/HelperFunctions/HelperFunctions_GetFewestBillMixList.cs
@@ -1,0 +1,25 @@
+﻿using Contract;
+
+namespace LogLineHandler
+{
+   public class HelperFunctions_GetFewestBillMixList : HelperFunctions
+   {
+      public string fewestbillmixlist;
+      public HelperFunctions_GetFewestBillMixList(ILogFileHandler parent, string logLine, APLogType apType = APLogType.HelperFunctions_GetFewestBillMixList) : base(parent, logLine, apType)
+      {
+      }
+
+      protected override void Initialize()
+      {
+         base.Initialize();
+
+         string findMe = "FewestBillMixList:";
+
+         int idx = logLine.LastIndexOf(findMe);
+         if (idx != -1)
+         {
+            fewestbillmixlist = logLine.Substring(idx + findMe.Length).Trim();
+         }
+      }
+   }
+}

--- a/src/APLine/NDC/Atm2Host/Atm2Host.cs
+++ b/src/APLine/NDC/Atm2Host/Atm2Host.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Contract;
+
+namespace LogLineHandler
+{
+   public class Atm2Host : NDC
+   {
+      public string myName = "Atm2Host";
+
+      public Atm2Host(ILogFileHandler parent, string logLine, APLogType apType) : base(parent, logLine, apType)
+      {
+      }
+
+      public static ILogLine Factory(ILogFileHandler logFileHandler, string logLine)
+      {
+         (bool success, string subLine) result = NDC.IsolateNdcMessage(logLine);
+         if (!result.success)
+         {
+            return null;
+         }
+         try
+         {
+            (bool success, string field, string subMessage) result2 = NDC.GetNextFieldBySeparator(result.subLine);
+
+            if (result2.success && result2.field.StartsWith("1"))
+               return new Host2Atm1(logFileHandler, logLine, APLogType.Atm2Host11);
+         }
+         catch (Exception e)
+         {
+            logFileHandler.ctx.ConsoleWriteLogLine(String.Format("Atm2Host ILogLine.Factory - NDC parsing error - {0}", e.Message));
+         }
+
+         return null;
+
+      }
+   }
+}

--- a/src/APLine/NDC/Atm2Host/Atm2Host11.cs
+++ b/src/APLine/NDC/Atm2Host/Atm2Host11.cs
@@ -1,0 +1,20 @@
+﻿using Contract;
+
+namespace LogLineHandler
+{
+   public class Atm2Host11 : Atm2Host
+   {
+      public string amount = string.Empty;
+
+      public Atm2Host11(ILogFileHandler parent, string logLine, APLogType apType = APLogType.Atm2Host11) : base(parent, logLine, apType)
+      {
+      }
+
+      protected override void Initialize()
+      {
+         base.Initialize();
+
+
+      }
+   }
+}

--- a/src/APLine/NDC/Host2Atm/Host2Atm.cs
+++ b/src/APLine/NDC/Host2Atm/Host2Atm.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Contract;
+
+namespace LogLineHandler
+{
+   public class Host2Atm : NDC
+   {
+      public string myName = "Host2Atm";
+
+      public Host2Atm(ILogFileHandler parent, string logLine, APLogType apType) : base(parent, logLine, apType)
+      {
+      }
+
+      public static ILogLine Factory(ILogFileHandler logFileHandler, string logLine)
+      {
+         (bool success, string subLine) result = NDC.IsolateNdcMessage(logLine);
+         if (!result.success)
+         {
+            return null;
+         }
+         try
+         {
+            (bool success, string field, string subMessage) result2 = NDC.GetNextFieldBySeparator(result.subLine);
+
+            if (result2.success && result2.field.StartsWith("1"))
+               return new Host2Atm1(logFileHandler, logLine, APLogType.Host2Atm1);
+         }
+         catch (Exception e)
+         {
+            logFileHandler.ctx.ConsoleWriteLogLine(String.Format("Host2Atm ILogLine.Factory - NDC parsing error - {0}", e.Message));
+         }
+
+         return null;
+      }
+
+   }
+}

--- a/src/APLine/NDC/Host2Atm/Host2Atm1.cs
+++ b/src/APLine/NDC/Host2Atm/Host2Atm1.cs
@@ -1,0 +1,19 @@
+﻿using Contract;
+
+namespace LogLineHandler
+{
+   public class Host2Atm1 : Host2Atm
+   {
+
+      public Host2Atm1(ILogFileHandler parent, string logLine, APLogType apType = APLogType.Host2Atm1) : base(parent, logLine, apType)
+      {
+      }
+
+      protected override void Initialize()
+      {
+         base.Initialize();
+
+
+      }
+   }
+}

--- a/src/APLine/NDC/NDC.cs
+++ b/src/APLine/NDC/NDC.cs
@@ -1,0 +1,218 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Contract;
+
+namespace LogLineHandler
+{
+   public class NDC : APLine
+   {
+      public string msgclass = string.Empty;
+      public string msgsubclass = string.Empty;
+      public string luno = string.Empty;
+      public string msn = string.Empty;
+      public string ndcmsg = string.Empty;
+      public string english = "Unknown ";
+
+      public NDC(ILogFileHandler parent, string logLine, APLogType apType) : base(parent, logLine, apType)
+      {
+      }
+
+      public virtual bool ParseToEnglishBrief()
+      {
+         return false;
+      }
+
+      public virtual bool ParseToEnglish()
+      {
+         return false;
+      }
+
+      public static (bool success, string xfsMatch, string subLogLine) NDCMatch(string logLine, string regStr, string def = "0")
+      {
+         Regex timeRegex = new Regex(regStr);
+         Match m = timeRegex.Match(logLine);
+         if (m.Success)
+         {
+            return (true, m.Groups[1].Value, logLine.Substring(m.Index));
+         }
+
+         return (false, def, logLine);
+      }
+
+      public static string[] NDCMatchTable(string logLine, string regStr)
+      {
+         List<string> values = new List<string>();
+         Regex regEx = new Regex(regStr);
+         Match m = regEx.Match(logLine);
+         if (m.Success)
+         {
+            values = m.Groups[0].Value.Split('\t').ToList();
+            values.RemoveAll(s => s == "");
+         }
+
+         return values.ToArray();
+      }
+
+      /// <summary>
+      /// Similar to the above except here we are dealing with a list type log line, not a table, 
+      /// so we are returning distinct single values not a list. 
+      /// This is identical to the GenericMatch in _wft_inf_cdm_status so there's a case to abstract into a
+      /// separate class all the different regex functions
+      /// </summary>
+      /// <param name="regEx"></param>
+      /// <param name="logLine"></param>
+      /// <returns></returns>
+      public static (bool success, string xfsMatch, string subLogLine) NDCMatchList(string logLine, string regStr, string def = "0")
+      {
+         Regex regEx = new Regex(regStr);
+         Match m = regEx.Match(logLine);
+         if (m.Success)
+         {
+            return (true, m.Groups[1].Value, logLine.Substring(m.Index));
+         }
+
+         return (false, def, logLine);
+      }
+
+
+      // e.g. lpulValues = [0, 0, 0, 4, 4, 0],
+      public static (bool success, string[] xfsMatch, string subLogLine) NDCMatchListToArray(string logLine, string regStr)
+      {
+         Regex typeRegex = new Regex(regStr);
+         Match m = typeRegex.Match(logLine);
+         if (m.Success)
+         {
+            List<string> usTypes = m.Groups[0].Value.Split(',').ToList();
+            usTypes.RemoveAll(s => s == "");
+            string[] usTypesArray = usTypes.ToArray();
+            for (int i = 0; i < usTypesArray.Length; i++)
+               usTypesArray[i] = usTypesArray[i].Trim();
+            return (true, usTypesArray, logLine.Substring(m.Index));
+         }
+
+         return (false, null, logLine);
+      }
+
+      /// <summary>
+      /// Generic pull out usCount. There are two forms 'usCount=5' and 'usCount = [5]'
+      /// </summary>
+      /// <param name="logLine">xfs log line </param>
+      /// <param name="regStr">regular expression identifying usCount</param>
+      /// <param name="def">default return value</param>
+      /// <returns></returns>
+      public static int NDCMatchInt(string logLine, string regStr, int def = 0)
+      {
+         Regex countRegex = new Regex(regStr);
+         Match m = countRegex.Match(logLine);
+         if (m.Success)
+         {
+            return int.Parse(m.Groups[1].Value);
+         }
+
+         return def;
+      }
+
+      public static string[] Resize(string[] values, int ulCount, string defValue = "0")
+      {
+         int oldSize = values.Length;
+         Array.Resize(ref values, ulCount);
+         for (int i = oldSize; i < ulCount; i++)
+         {
+            values[i] = defValue;
+         }
+         return values;
+      }
+
+      public static string[] TrimAll(string[] values)
+      {
+         return values.Select(value => value.Trim()).ToArray();
+      }
+
+      /// <summary>
+      /// Given a list format pull off in strings the next logical unit for processing
+      /// </summary>
+      /// <param name="logLine"></param>
+      /// <returns></returns>
+      public static (string thisLogicalUnit, string nextLogicalUnits) NextLogicalUnit(string logLine)
+      {
+         int indexOfOpenBracket = logLine.IndexOf('{');
+         if (indexOfOpenBracket < 0)
+         {
+            return (string.Empty, logLine);
+         }
+
+         string subLogLine = logLine.Substring(indexOfOpenBracket);
+         int endPos = -1;
+         int bracketCount = 0;
+
+         foreach (char c in subLogLine)
+         {
+            // endPos is the index of 'c'
+            endPos++;
+            if (c.Equals('{'))
+            {
+               bracketCount++;
+            }
+            else if (c.Equals('}'))
+            {
+               bracketCount--;
+            }
+            if (bracketCount == 0)
+            {
+               break;
+            }
+         }
+
+         return (subLogLine.Substring(0, endPos), subLogLine.Substring(endPos + 1));
+      }
+
+      public static (bool, string) IsolateNdcMessage(string logLine)
+      {
+         string atm2Host = "ATM2HOST: ";
+         string host2Atm = "HOST2ATM: ";
+
+         int idx = logLine.IndexOf(atm2Host);
+         if (idx >= 0)
+            return (true, logLine.Substring(idx + atm2Host.Length));
+
+         idx = logLine.IndexOf(host2Atm);
+         if (idx >= 0)
+            return (true, logLine.Substring(idx + host2Atm.Length));
+
+         return (false, logLine);
+      }
+
+      public static (bool, string, string) GetNextFieldBySeparator(string ndcMessage, string separatorHex = "1c")
+      {
+         char separator = (char)Convert.ToInt32(separatorHex, 16);
+
+         int idx = ndcMessage.IndexOf(separator);
+         if (idx < 0)
+         {
+            // error
+            return (false, string.Empty, ndcMessage);
+         }
+         if (idx == 0)
+         {
+            return (true, string.Empty, ndcMessage.Substring(idx + 1));
+         }
+
+         return (true, ndcMessage.Substring(0, idx), ndcMessage.Substring(idx + 1));
+      }
+
+      public (bool, string, string) GetNextFieldBySize(string ndcMessage, int size)
+      {
+         return (true, ndcMessage.Substring(0, size), ndcMessage.Substring(size));
+      }
+
+      public static string[] SplitMessage(string logLine)
+      {
+         string separatorHex = "1c";
+         char separator = (char)Convert.ToInt32(separatorHex, 16);
+
+         return Regex.Split(logLine, separator.ToString());
+      }
+   }
+}

--- a/src/APLogLineTests/APLogHandler_IdentifyLines_CashDispenser_Tests.cs
+++ b/src/APLogLineTests/APLogHandler_IdentifyLines_CashDispenser_Tests.cs
@@ -372,6 +372,7 @@ namespace APLogLineTests
 
       }
 
+      [TestMethod]
       public void CashDispenser_OnDispenseComplete()
       {
          ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
@@ -383,6 +384,7 @@ namespace APLogLineTests
          Assert.IsTrue(apLine.Timestamp == "2023-10-31 20:57:33.721");
          Assert.IsTrue(apLine.HResult == "");
       }
+      [TestMethod]
       public void CashDispenser_OnPresentComplete()
       {
          ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
@@ -394,6 +396,8 @@ namespace APLogLineTests
          Assert.IsTrue(apLine.Timestamp == "2023-10-31 20:57:36.543");
          Assert.IsTrue(apLine.HResult == "");
       }
+
+      [TestMethod]
       public void CashDispenser_OnItemsTaken()
       {
          ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
@@ -406,6 +410,7 @@ namespace APLogLineTests
          Assert.IsTrue(apLine.HResult == "");
       }
 
+      [TestMethod]
       public void CashDispenser_GetLCULastDispensedCount()
       {
          ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
@@ -414,10 +419,11 @@ namespace APLogLineTests
 
          CashDispenser_GetLCULastDispensedCount apLine = (CashDispenser_GetLCULastDispensedCount)logLine;
          Assert.IsTrue(apLine.apType == APLogType.CashDispenser_GetLCULastDispensedCount);
-         Assert.IsTrue(apLine.Timestamp == "[2023-10-31 20:57:36.555");
+         Assert.IsTrue(apLine.Timestamp == "2023-10-31 20:57:36.555");
          Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.noteType == "A");
+         Assert.IsTrue(apLine.amount == "0");
       }
-
-
    }
 }

--- a/src/APLogLineTests/APLogHandler_IdentifyLines_Core_Tests.cs
+++ b/src/APLogLineTests/APLogHandler_IdentifyLines_Core_Tests.cs
@@ -1,0 +1,483 @@
+﻿using LogFileHandler;
+using LogLineHandler;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Contract;
+using APSamples;
+
+namespace APLogLineTests
+{
+   [TestClass]
+   public class APLogHandler_IdentifyLines_Core_Tests
+   {
+      /* CORE */
+
+      /* FiservDNA */
+
+      [TestMethod]
+      public void Core_ProcessWithdrawalTransaction_Amount_1()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_ProcessWithdrawalTransaction_Amount_1);
+         Assert.IsTrue(logLine is Core_ProcessWithdrawalTransactionAmount);
+
+         Core_ProcessWithdrawalTransactionAmount apLine = (Core_ProcessWithdrawalTransactionAmount)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_ProcessWithdrawalTransaction_Amount);
+         Assert.IsTrue(apLine.Timestamp == "2023-06-07 12:18:15.179");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "FiservDNA");
+         Assert.IsTrue(apLine.amount == "500");
+      }
+
+      [TestMethod]
+      public void Core_ProcessWithdrawalTransaction_Account_1()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_ProcessWithdrawalTransaction_Account_1);
+         Assert.IsTrue(logLine is Core_ProcessWithdrawalTransactionAccount);
+
+         Core_ProcessWithdrawalTransactionAccount apLine = (Core_ProcessWithdrawalTransactionAccount)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_ProcessWithdrawalTransaction_Account);
+         Assert.IsTrue(apLine.Timestamp == "2023-11-16 11:09:19.900");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "FiservDNA");
+         Assert.IsTrue(apLine.account == "XXX5754");
+      }
+
+      [TestMethod]
+      public void Core_RequiredBillMixList_1()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_RequiredBillMixList_1);
+         Assert.IsTrue(logLine is Core_RequiredBillMixList);
+
+         Core_RequiredBillMixList apLine = (Core_RequiredBillMixList)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_RequiredBillMixList);
+         Assert.IsTrue(apLine.Timestamp == "2023-06-07 12:18:15.596");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "FiservDNA");
+         Assert.IsTrue(apLine.requiredbillmixlist == "100~0|20~6|5~76");
+      }
+
+      [TestMethod]
+      public void Core_DispensedAmount_1()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_DispensedAmount_1);
+         Assert.IsTrue(logLine is Core_DispensedAmount);
+
+         Core_DispensedAmount apLine = (Core_DispensedAmount)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_DispensedAmount);
+         Assert.IsTrue(apLine.Timestamp == "2023-06-07 12:18:33.379");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "FiservDNA");
+         Assert.IsTrue(apLine.amount == "500");
+      }
+
+
+      /* JackHenry */
+
+      [TestMethod]
+      public void Core_ProcessWithdrawalTransaction_Amount_2()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_ProcesWithdrawalTransaction_Amount_2);
+         Assert.IsTrue(logLine is Core_ProcessWithdrawalTransactionAmount);
+
+         Core_ProcessWithdrawalTransactionAmount apLine = (Core_ProcessWithdrawalTransactionAmount)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_ProcessWithdrawalTransaction_Amount);
+         Assert.IsTrue(apLine.Timestamp == "2023-10-05 16:16:11.896");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "JackHenry");
+         Assert.IsTrue(apLine.amount == "60");
+      }
+
+      [TestMethod]
+      public void Core_ProcessWithdrawalTransaction_Account_2()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_ProcessWithdrawalTransaction_Account_2);
+         Assert.IsTrue(logLine is Core_ProcessWithdrawalTransactionAccount);
+
+         Core_ProcessWithdrawalTransactionAccount apLine = (Core_ProcessWithdrawalTransactionAccount)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_ProcessWithdrawalTransaction_Account);
+         Assert.IsTrue(apLine.Timestamp == "2023-10-05 14:46:27.344");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "JackHenry");
+         Assert.IsTrue(apLine.account == "x4361");
+      }
+
+      [TestMethod]
+      public void Core_RequiredBillMixList_2()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_RequiredBillMixList_2);
+         Assert.IsTrue(logLine is Core_RequiredBillMixList);
+
+         Core_RequiredBillMixList apLine = (Core_RequiredBillMixList)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_RequiredBillMixList);
+         Assert.IsTrue(apLine.Timestamp == "2023-11-21 12:13:05.982");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "JackHenry");
+         Assert.IsTrue(apLine.requiredbillmixlist == "100~0|20~4|5~4|1~0");
+      }
+
+      [TestMethod]
+      public void Core_DispensedAmount_2()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_DispensedAmount_2);
+         Assert.IsTrue(logLine is Core_DispensedAmount);
+
+         Core_DispensedAmount apLine = (Core_DispensedAmount)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_DispensedAmount);
+         Assert.IsTrue(apLine.Timestamp == "2023-11-21 12:13:14.418");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "JackHenry");
+         Assert.IsTrue(apLine.amount == "100");
+      }
+
+
+      /* SymXchange */
+
+      [TestMethod]
+      public void Core_ProcessWithdrawalTransaction_Amount_3()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_ProcessWithdrawalTransaction_Amount_3);
+         Assert.IsTrue(logLine is Core_ProcessWithdrawalTransactionAmount);
+
+         Core_ProcessWithdrawalTransactionAmount apLine = (Core_ProcessWithdrawalTransactionAmount)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_ProcessWithdrawalTransaction_Amount);
+         Assert.IsTrue(apLine.Timestamp == "2023-11-13 10:37:45.919");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "SymXchange");
+         Assert.IsTrue(apLine.amount == "800");
+      }
+
+      [TestMethod]
+      public void Core_ProcessWithdrawalTransaction_Account_3()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_ProcessWithdrawalTransaction_Account_3);
+         Assert.IsTrue(logLine is Core_ProcessWithdrawalTransactionAccount);
+
+         Core_ProcessWithdrawalTransactionAccount apLine = (Core_ProcessWithdrawalTransactionAccount)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_ProcessWithdrawalTransaction_Account);
+         Assert.IsTrue(apLine.Timestamp == "2023-11-13 10:37:45.914");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "SymXchange");
+         Assert.IsTrue(apLine.account == "XXXXXX8451");
+      }
+
+      [TestMethod]
+      public void Core_RequiredBillMixList_3()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_RequiredBillMixList_3);
+         Assert.IsTrue(logLine is Core_RequiredBillMixList);
+
+         Core_RequiredBillMixList apLine = (Core_RequiredBillMixList)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_RequiredBillMixList);
+         Assert.IsTrue(apLine.Timestamp == "2023-11-22 14:53:08.481");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "SymXchange");
+         Assert.IsTrue(apLine.requiredbillmixlist == "100~0|20~25|5~0|1~0");
+      }
+
+      [TestMethod]
+      public void Core_DispensedAmount_3()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_DispensedAmount_3);
+         Assert.IsTrue(logLine is Core_DispensedAmount);
+
+         Core_DispensedAmount apLine = (Core_DispensedAmount)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_DispensedAmount);
+         Assert.IsTrue(apLine.Timestamp == "2023-11-22 14:53:20.513");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "SymXchange");
+         Assert.IsTrue(apLine.amount == "500");
+      }
+
+
+      /* CUAnswers */
+
+      [TestMethod]
+      public void Core_ProcessWithdrawalTransaction_Amount_4()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_ProcessWithdrawalTransaction_Amount_4);
+         Assert.IsTrue(logLine is Core_ProcessWithdrawalTransactionAmount);
+
+         Core_ProcessWithdrawalTransactionAmount apLine = (Core_ProcessWithdrawalTransactionAmount)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_ProcessWithdrawalTransaction_Amount);
+         Assert.IsTrue(apLine.Timestamp == "2023-11-06 14:59:17.355");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "CUAnswers");
+         Assert.IsTrue(apLine.amount == "60");
+      }
+
+      [TestMethod]
+      public void Core_ProcessWithdrawalTransaction_Account_4()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_ProcessWithdrawalTransaction_Account_4);
+         Assert.IsTrue(logLine is Core_ProcessWithdrawalTransactionAccount);
+
+         Core_ProcessWithdrawalTransactionAccount apLine = (Core_ProcessWithdrawalTransactionAccount)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_ProcessWithdrawalTransaction_Account);
+         Assert.IsTrue(apLine.Timestamp == "2023-11-06 14:59:17.350");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "CUAnswers");
+         Assert.IsTrue(apLine.account == "XX9725");
+      }
+
+      [TestMethod]
+      public void Core_RequiredBillMixList_4()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_RequiredBillMixList_4);
+         Assert.IsTrue(logLine is Core_RequiredBillMixList);
+
+         Core_RequiredBillMixList apLine = (Core_RequiredBillMixList)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_RequiredBillMixList);
+         Assert.IsTrue(apLine.Timestamp == "2023-11-06 14:59:23.484");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "CUAnswers");
+         Assert.IsTrue(apLine.requiredbillmixlist == "100~0|20~2|5~4|1~0");
+      }
+
+      [TestMethod]
+      public void Core_DispensedAmount_4()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_DispensedAmount_4);
+         Assert.IsTrue(logLine is Core_DispensedAmount);
+
+         Core_DispensedAmount apLine = (Core_DispensedAmount)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_DispensedAmount);
+         Assert.IsTrue(apLine.Timestamp == "2023-11-06 14:59:31.859");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "CUAnswers");
+         Assert.IsTrue(apLine.amount == "60");
+      }
+
+      /* CMFlex */
+
+
+      [TestMethod]
+      public void Core_ProcessWithdrawalTransaction_Amount_5()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_ProcessWithdrawalTransaction_Amount_5);
+         Assert.IsTrue(logLine is Core_ProcessWithdrawalTransactionAmount);
+
+         Core_ProcessWithdrawalTransactionAmount apLine = (Core_ProcessWithdrawalTransactionAmount)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_ProcessWithdrawalTransaction_Amount);
+         Assert.IsTrue(apLine.Timestamp == "2023-12-04 10:32:45.152");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "CMCFlex");
+         Assert.IsTrue(apLine.amount == "1");
+      }
+
+      [TestMethod]
+      public void Core_ProcessWithdrawalTransaction_Account_5()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_ProcessWithdrawalTransaction_Account_5);
+         Assert.IsTrue(logLine is Core_ProcessWithdrawalTransactionAccount);
+
+         Core_ProcessWithdrawalTransactionAccount apLine = (Core_ProcessWithdrawalTransactionAccount)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_ProcessWithdrawalTransaction_Account);
+         Assert.IsTrue(apLine.Timestamp == "2023-12-04 10:32:45.144");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "CMCFlex");
+         Assert.IsTrue(apLine.account == "x2754");
+      }
+
+      [TestMethod]
+      public void Core_RequiredBillMixList_5()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_RequiredBillMixList_5);
+         Assert.IsTrue(logLine is Core_RequiredBillMixList);
+
+         Core_RequiredBillMixList apLine = (Core_RequiredBillMixList)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_RequiredBillMixList);
+         Assert.IsTrue(apLine.Timestamp == "2023-12-04 10:33:03.975");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "CMCFlex");
+         Assert.IsTrue(apLine.requiredbillmixlist == "100~0|20~0|5~0|1~1");
+      }
+
+      [TestMethod]
+      public void Core_DispensedAmount_5()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_DispensedAmount_5);
+         Assert.IsTrue(logLine is Core_DispensedAmount);
+
+         Core_DispensedAmount apLine = (Core_DispensedAmount)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_DispensedAmount);
+         Assert.IsTrue(apLine.Timestamp == "2023-12-04 10:33:12.687");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "CMCFlex");
+         Assert.IsTrue(apLine.amount == "1");
+      }
+
+      /* KeyBridge */
+
+
+      [TestMethod]
+      public void Core_ProcessWithdrawalTransaction_Amount_6()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_ProcessWithdrawalTransaction_Amount_6);
+         Assert.IsTrue(logLine is Core_ProcessWithdrawalTransactionAmount);
+
+         Core_ProcessWithdrawalTransactionAmount apLine = (Core_ProcessWithdrawalTransactionAmount)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_ProcessWithdrawalTransaction_Amount);
+         Assert.IsTrue(apLine.Timestamp == "2023-12-12 10:39:36.985");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "KeyBridge");
+         Assert.IsTrue(apLine.amount == "100");
+      }
+
+      [TestMethod]
+      public void Core_ProcessWithdrawalTransaction_Account_6()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_ProcessWithdrawalTransaction_Account_6);
+         Assert.IsTrue(logLine is Core_ProcessWithdrawalTransactionAccount);
+
+         Core_ProcessWithdrawalTransactionAccount apLine = (Core_ProcessWithdrawalTransactionAccount)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_ProcessWithdrawalTransaction_Account);
+         Assert.IsTrue(apLine.Timestamp == "2023-12-12 10:39:36.984");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "KeyBridge");
+         Assert.IsTrue(apLine.account == "XXX3160");
+      }
+
+      [TestMethod]
+      public void Core_RequiredBillMixList_6()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_RequiredBillMixList_6);
+         Assert.IsTrue(logLine is Core_RequiredBillMixList);
+
+         Core_RequiredBillMixList apLine = (Core_RequiredBillMixList)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_RequiredBillMixList);
+         Assert.IsTrue(apLine.Timestamp == "2023-12-12 02:02:49.495");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "KeyBridge");
+         Assert.IsTrue(apLine.requiredbillmixlist == "20~1");
+      }
+
+      [TestMethod]
+      public void Core_DispensedAmount_6()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_DispensedAmount_6);
+         Assert.IsTrue(logLine is Core_DispensedAmount);
+
+         Core_DispensedAmount apLine = (Core_DispensedAmount)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_DispensedAmount);
+         Assert.IsTrue(apLine.Timestamp == "2023-12-12 02:02:57.167");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "KeyBridge");
+         Assert.IsTrue(apLine.amount == "20");
+      }
+
+      /* AccessAdvantage */
+
+
+      [TestMethod]
+      public void Core_ProcessWithdrawalTransaction_Amount_7()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_ProcessWithdrawalTransaction_Amount_7);
+         Assert.IsTrue(logLine is Core_ProcessWithdrawalTransactionAmount);
+
+         Core_ProcessWithdrawalTransactionAmount apLine = (Core_ProcessWithdrawalTransactionAmount)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_ProcessWithdrawalTransaction_Amount);
+         Assert.IsTrue(apLine.Timestamp == "2023-12-04 09:03:47.232");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "AccessAdvantage");
+         Assert.IsTrue(apLine.amount == "25");
+      }
+
+      [TestMethod]
+      public void Core_ProcessWithdrawalTransaction_Account_7()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_ProcessWithdrawalTransaction_Account_7);
+         Assert.IsTrue(logLine is Core_ProcessWithdrawalTransactionAccount);
+
+         Core_ProcessWithdrawalTransactionAccount apLine = (Core_ProcessWithdrawalTransactionAccount)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_ProcessWithdrawalTransaction_Account);
+         Assert.IsTrue(apLine.Timestamp == "2023-12-04 09:03:47.232");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "AccessAdvantage");
+         Assert.IsTrue(apLine.account == "X4050");
+      }
+
+      [TestMethod]
+      public void Core_RequiredBillMixList_7()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_RequiredBillMixList_7);
+         Assert.IsTrue(logLine is Core_RequiredBillMixList);
+
+         Core_RequiredBillMixList apLine = (Core_RequiredBillMixList)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_RequiredBillMixList);
+         Assert.IsTrue(apLine.Timestamp == "2023-12-04 09:03:48.015");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "AccessAdvantage");
+         Assert.IsTrue(apLine.requiredbillmixlist == "100~0|20~1|5~1|1~0");
+      }
+
+      [TestMethod]
+      public void Core_DispensedAmount_7()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_core.Core_DispensedAmount_7);
+         Assert.IsTrue(logLine is Core_DispensedAmount);
+
+         Core_DispensedAmount apLine = (Core_DispensedAmount)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.Core_DispensedAmount);
+         Assert.IsTrue(apLine.Timestamp == "2023-12-04 09:03:55.474");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.name == "AccessAdvantage");
+         Assert.IsTrue(apLine.amount == "25");
+      }
+
+   }
+}

--- a/src/APLogLineTests/APLogHandler_IdentifyLines_HelperFunctions_Tests.cs
+++ b/src/APLogLineTests/APLogHandler_IdentifyLines_HelperFunctions_Tests.cs
@@ -1,0 +1,48 @@
+﻿using LogFileHandler;
+using LogLineHandler;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Contract;
+using APSamples;
+
+namespace APLogLineTests
+{
+   [TestClass]
+   public class APLogHandler_IdentifyLines_HelperFunctions_Tests
+   {
+      /* CORE */
+
+      /* FiservDNA */
+
+      [TestMethod]
+      public void HelperFunctions_GetConfiguredBillMixList()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_helperfunctions.HelperFunctions_GetConfiguredBillMixList);
+         Assert.IsTrue(logLine is HelperFunctions_GetConfiguredBillMixList);
+
+         HelperFunctions_GetConfiguredBillMixList apLine = (HelperFunctions_GetConfiguredBillMixList)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.HelperFunctions_GetConfiguredBillMixList);
+         Assert.IsTrue(apLine.Timestamp == "2023-12-19 20:18:13.380");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.configuredbillmixlist == "20~2|5~0");
+
+      }
+
+      [TestMethod]
+      public void HelperFunctions_GetFewestBillMixList()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_helperfunctions.HelperFunctions_GetFewestBillMixList);
+         Assert.IsTrue(logLine is HelperFunctions_GetFewestBillMixList);
+
+         HelperFunctions_GetFewestBillMixList apLine = (HelperFunctions_GetFewestBillMixList)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.HelperFunctions_GetFewestBillMixList);
+         Assert.IsTrue(apLine.Timestamp == "2023-12-19 22:30:32.531");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.fewestbillmixlist == "20~5|5~0");
+
+      }
+   }
+}

--- a/src/APLogLineTests/APLogHandler_ReadLine_Tests.cs
+++ b/src/APLogLineTests/APLogHandler_ReadLine_Tests.cs
@@ -141,7 +141,7 @@ namespace APLogLineTests
 
          logLine = logFileHandler.IdentifyLine(logFileHandler.ReadLine());
          Assert.IsTrue(logLine is APLine);
-         
+
          apLine = (APLine)logLine;
          Assert.IsTrue(apLine.Timestamp == "2023-03-30 18:53:05.457");
       }
@@ -191,8 +191,8 @@ namespace APLogLineTests
          ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock());
          logFileHandler.OpenLogFile(samples_entirefile.SAMPLE_FILE);
 
-         _ = logFileHandler.ReadLine(); 
-         while(!logFileHandler.EOF())
+         _ = logFileHandler.ReadLine();
+         while (!logFileHandler.EOF())
          {
             try
             {

--- a/src/APLogLineTests/APLogLineTests.csproj
+++ b/src/APLogLineTests/APLogLineTests.csproj
@@ -50,6 +50,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="APLineTests.cs" />
+    <Compile Include="APLogHandler_IdentifyLines_HelperFunctions_Tests.cs" />
+    <Compile Include="APLogHandler_IdentifyLines_Core_Tests.cs" />
     <Compile Include="APLogHandler_IdentifyLines_CashDispenser_Tests.cs" />
     <Compile Include="CreateTextStreamReaderMock.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/APLogLineTests/packages.config
+++ b/src/APLogLineTests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="3.1.1" targetFramework="net472" />
+</packages>

--- a/src/APSamplesTests/APSamples.csproj
+++ b/src/APSamplesTests/APSamples.csproj
@@ -43,6 +43,8 @@
   <ItemGroup>
     <Compile Include="samples_apfilereader.cs" />
     <Compile Include="samples_cashdepot_loglines.cs" />
+    <Compile Include="samples_helperfunctions.cs" />
+    <Compile Include="samples_core.cs" />
     <Compile Include="samples_cashdisp.cs" />
     <Compile Include="samples_ejcommands.cs" />
     <Compile Include="samples_ejinsert.cs" />

--- a/src/APSamplesTests/samples_core.cs
+++ b/src/APSamplesTests/samples_core.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace APSamples
+{
+   public class samples_core
+   {
+      /* CORE */
+
+
+      /* FiservDNA */
+
+      public const string Core_ProcessWithdrawalTransaction_Amount_1 =
+      @"[2023-06-07 12:18:15-179][3][][FiservDNAWebServiceRequestFlowPoint][ProcessWithdrawalTransaction][NORMAL]Total Amount: 500
+";
+      public const string Core_ProcessWithdrawalTransaction_Account_1 =
+      @"[2023-11-16 11:09:19-900][3][][FiservDNAWebServiceRequestFlowPoint][ProcessWithdrawalTransaction][NORMAL]Account Number: XXX5754
+";
+      public const string Core_RequiredBillMixList_1 =
+      @"[2023-06-07 12:18:15-596][3][][FiservDNAWebServiceRequestFlowPoint][DispenseCurrency    ][NORMAL]RequiredBillMixList: 100~0|20~6|5~76
+";
+      public const string Core_DispensedAmount_1 =
+      @"[2023-06-07 12:18:33-379][3][][FiservDNAWebServiceRequestFlowPoint][DispenseCurrency    ][NORMAL]dispensedAmount= 500
+";
+
+      /* JackHenry */
+
+      public const string Core_ProcesWithdrawalTransaction_Amount_2 =
+      @"[2023-10-05 16:16:11-896][3][][JackHenryWebServiceRequestFlowPoint][ProcessWithdrawalTransaction][NORMAL]Amount - 60
+";
+      public const string Core_ProcessWithdrawalTransaction_Account_2 =
+      @"[2023-10-05 14:46:27-344][3][][JackHenryWebServiceRequestFlowPoint][ProcessWithdrawalTransaction][NORMAL]Account Number - x4361, Account Type - D, Transaction Code - 58
+";
+      public const string Core_RequiredBillMixList_2 =
+      @"[2023-11-21 12:13:05-982][3][][JackHenryWebServiceRequestFlowPoint][DispenseCurrency    ][NORMAL]RequiredBillMixList: 100~0|20~4|5~4|1~0
+";
+
+      public const string Core_DispensedAmount_2 =
+      @"[2023-11-21 12:13:14-418][3][][JackHenryWebServiceRequestFlowPoint][DispenseCurrency    ][NORMAL]dispensedAmount= 100
+";
+
+      /* SymXchange */
+
+      public const string Core_ProcessWithdrawalTransaction_Amount_3 =
+      @"[2023-11-13 10:37:45-919][3][][SymXchangeWebServiceRequestFlowPoint][ProcessWithdrawalTransaction][NORMAL]Total Amount: 800
+";
+      public const string Core_ProcessWithdrawalTransaction_Account_3 =
+      @"[2023-11-13 10:37:45-914][3][][SymXchangeWebServiceRequestFlowPoint][ProcessWithdrawalTransaction][NORMAL]Account Number: XXXXXX8451
+";
+      public const string Core_RequiredBillMixList_3 =
+      @"[2023-11-22 14:53:08-481][3][][SymXchangeWebServiceRequestFlowPoint][DispenseCurrency    ][NORMAL]RequiredBillMixList: 100~0|20~25|5~0|1~0
+";
+      public const string Core_DispensedAmount_3 =
+      @"[2023-11-22 14:53:20-513][3][][SymXchangeWebServiceRequestFlowPoint][DispenseCurrency    ][NORMAL]dispensedAmount= 500
+";
+
+      /* CUAnswers */
+
+      public const string Core_ProcessWithdrawalTransaction_Amount_4 =
+      @"[2023-11-06 14:59:17-355][3][][CUAnswersWebServiceRequestFlowPoint][ProcessWithdrawalTransaction][NORMAL]Total Amount: 60
+";
+      public const string Core_ProcessWithdrawalTransaction_Account_4 =
+      @"[2023-11-06 14:59:17-350][3][][CUAnswersWebServiceRequestFlowPoint][ProcessWithdrawalTransaction][NORMAL]Account Number: XX9725
+";
+      public const string Core_RequiredBillMixList_4 =   
+      @"[2023-11-06 14:59:23-484][3][][CUAnswersWebServiceRequestFlowPoint][DispenseCurrency    ][NORMAL]RequiredBillMixList: 100~0|20~2|5~4|1~0
+";
+      public const string Core_DispensedAmount_4 =
+      @"[2023-11-06 14:59:31-859][3][][CUAnswersWebServiceRequestFlowPoint][DispenseCurrency    ][NORMAL]dispensedAmount= 60
+";
+
+      /* CMCFlex */
+
+      public const string Core_ProcessWithdrawalTransaction_Amount_5 =
+      @"[2023-12-04 10:32:45-152][3][][CMCFlexWebServiceRequestFlowPoint][ProcessWithdrawalTransaction][NORMAL]Amount: 1
+";
+      public const string Core_ProcessWithdrawalTransaction_Account_5 =
+      @"[2023-12-04 10:32:45-144][3][][CMCFlexWebServiceRequestFlowPoint][ProcessWithdrawalTransaction][NORMAL]Account Number: x2754
+";
+      public const string Core_RequiredBillMixList_5 =
+      @"[2023-12-04 10:33:03-975][3][][CMCFlexWebServiceRequestFlowPoint][DispenseCurrency    ][NORMAL]RequiredBillMixList: 100~0|20~0|5~0|1~1
+";
+      public const string Core_DispensedAmount_5 =
+      @"[2023-12-04 10:33:12-687][3][][CMCFlexWebServiceRequestFlowPoint][DispenseCurrency    ][NORMAL]dispensedAmount= 1
+";
+
+      /* KeyBridge */
+
+      public const string Core_ProcessWithdrawalTransaction_Amount_6 =
+      @"[2023-12-12 10:39:36-985][3][][KeyBridgeWebServiceRequestFlowPoint][ProcessWithdrawalTransaction][NORMAL]Total Amount: 100
+";
+      public const string Core_ProcessWithdrawalTransaction_Account_6 =
+      @"[2023-12-12 10:39:36-984][3][][KeyBridgeWebServiceRequestFlowPoint][ProcessWithdrawalTransaction][NORMAL]Account Number: XXX3160
+";
+      public const string Core_RequiredBillMixList_6 =
+      @"[2023-12-12 02:02:49-495][3][][KeyBridgeWebServiceRequestFlowPoint][DispenseCurrency    ][NORMAL]RequiredBillMixList: 20~1
+";
+      public const string Core_DispensedAmount_6 =
+      @"[2023-12-12 02:02:57-167][3][][KeyBridgeWebServiceRequestFlowPoint][DispenseCurrency    ][NORMAL]dispensedAmount= 20
+";
+
+      /* AccessAdvantage */
+
+      public const string Core_ProcessWithdrawalTransaction_Amount_7 =
+      @"[2023-12-04 09:03:47-232][3][][AccessAdvantageWebServiceRequestFlowPoint][ProcessWithdrawalTransaction][NORMAL]Total Amount: 25
+";
+      public const string Core_ProcessWithdrawalTransaction_Account_7 =
+      @"[2023-12-04 09:03:47-232][3][][AccessAdvantageWebServiceRequestFlowPoint][ProcessWithdrawalTransaction][NORMAL]Account Number: X4050
+";
+      public const string Core_RequiredBillMixList_7 =
+      @"[2023-12-04 09:03:48-015][3][][AccessAdvantageWebServiceRequestFlowPoint][DispenseCurrency    ][NORMAL]RequiredBillMixList: 100~0|20~1|5~1|1~0
+";
+      public const string Core_DispensedAmount_7 =
+      @"[2023-12-04 09:03:55-474][3][][AccessAdvantageWebServiceRequestFlowPoint][DispenseCurrency    ][NORMAL]dispensedAmount= 25
+";
+
+   }
+}

--- a/src/APSamplesTests/samples_helperfunctions.cs
+++ b/src/APSamplesTests/samples_helperfunctions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace APSamples
+{
+   public class samples_helperfunctions
+   {
+      public const string HelperFunctions_GetFewestBillMixList =
+      @"[2023-12-19 22:30:32-531][3][][HelperFunctions     ][GetFewestBillMixList][NORMAL]FewestBillMixList:20~5|5~0
+";
+      public const string HelperFunctions_GetConfiguredBillMixList =
+      @"[2023-12-19 20:18:13-380][3][][HelperFunctions     ][GetConfiguredBillMixList][NORMAL]ConfiguredBillMixList:20~2|5~0
+";
+   }
+}

--- a/src/BaseView/BaseTable.cs
+++ b/src/BaseView/BaseTable.cs
@@ -318,14 +318,14 @@ namespace Impl
          }
       }
 
-      protected virtual void DeleteRedundantRows(string tableName, string colName = "file")
+      protected virtual void DeleteRedundantRows(string tableName, string colName = "file", string critera = "")
       {
          ctx.ConsoleWriteLogLine(String.Format("Delete redundant rows from the {0} Table start: rows before: {1}", tableName, dTableSet.Tables[tableName].Rows.Count));
          DataRow[] dataRows = dTableSet.Tables[tableName].Select();
          List<DataRow> deleteRows = new List<DataRow>();
          foreach (DataRow dataRow in dataRows)
          {
-            if (dataRow[colName].ToString().Trim() == string.Empty)
+            if (dataRow[colName].ToString().Trim() == critera)
             {
                deleteRows.Add(dataRow);
             }
@@ -344,8 +344,18 @@ namespace Impl
       /// <param name="ctx"></param>
       public virtual void PreProcess(IContext ctx)
       {
-         return; 
+         return;
       }
+
+      /// <summary>
+      /// PreProcess - steps not related to time series
+      /// </summary>
+      /// <param name="ctx"></param>
+      public virtual void PostProcess()
+      {
+         return;
+      }
+
       /// <summary>
       /// Process a log line. 
       /// </summary>

--- a/src/BaseView/BaseView.cs
+++ b/src/BaseView/BaseView.cs
@@ -21,7 +21,7 @@ namespace Impl
       /// <summary>
       /// My base table(s)
       /// </summary>
-      protected BaseTable bTable; 
+      protected BaseTable bTable;
 
       /// <summary>
       /// Constructor. 
@@ -51,7 +51,7 @@ namespace Impl
       /// <param name="ctx"></param>
       public virtual void Initialize(IContext ctx)
       {
-         this.ctx = ctx; 
+         this.ctx = ctx;
 
          ctx.LogWriteLine("------------------------------------------------");
          ctx.LogWriteLine("Initialize: " + viewName);
@@ -62,7 +62,7 @@ namespace Impl
 
       public virtual void PreProcess(IContext ctx)
       {
-         return;   
+         return;
       }
 
       /// <summary>Call to process the datatable (merge of all log lines)</summary>
@@ -107,6 +107,7 @@ namespace Impl
          ctx.LogWriteLine("------------------------------------------------");
          ctx.LogWriteLine("Post Process: " + viewName);
 
+         bTable.PostProcess();
          bTable.WriteXmlFile();
       }
 

--- a/src/CashDispView/CashDispTable.cs
+++ b/src/CashDispView/CashDispTable.cs
@@ -1,0 +1,604 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using Contract;
+using Impl;
+using LogLineHandler;
+
+namespace CashDispView
+{
+   internal class CashDispTable : BaseTable
+   {
+      DataRow m_lcuRow;
+      DataRow m_denominated;
+
+      /// <summary>
+      /// constructor
+      /// </summary>
+      /// <param name="ctx">Context for the command.</param>
+      /// <param name="viewName">The (unique) name of the view being created.</param>
+      public CashDispTable(IContext ctx, string viewName) : base(ctx, viewName)
+      {
+         // for our view we want '0' to render as ' ' in the worksheet
+         _zeroAsBlank = true;
+      }
+
+      public override void PostProcess()
+      {
+         string tableName = string.Empty;
+
+         try
+         {
+            // S T A T U S  T A B L E
+
+            tableName = "Status";
+
+            // COMPRESS
+            string[] columns = new string[] { "error", "device", "position", "dispenser", "shutter", "stacker", "posstatus", "transport" };
+            CompressTable(tableName, columns);
+         }
+         catch (Exception e)
+         {
+            ctx.ConsoleWriteLogLine(message: String.Format("Exception processing the {0} table - {1}", tableName, e.Message));
+         }
+
+         try
+         {
+            tableName = "Dispense";
+
+            // COMPRESS
+            string[] columns = new string[] { "error", "position", "hostamount", "coreaccount", "billmix", "dispensedamount", "LU0", "LU1", "LU2", "LU3", "LU4", "LU5", "LU6", "LU7", "LU8", "LU9" };
+            CompressTable(tableName, columns);
+
+         }
+         catch (Exception e)
+         {
+            ctx.ConsoleWriteLogLine(message: String.Format("Exception processing the {0} table - {1}", tableName, e.Message));
+         }
+
+         try
+         {
+            // S U M M A R Y  T A B L E
+
+            tableName = "Summary";
+
+            // delete rows where the denom is -1, meaning not set
+            DeleteRedundantRows(tableName, "denom", "-1");
+
+         }
+         catch (Exception e)
+         {
+            ctx.ConsoleWriteLogLine(message: String.Format("Exception processing the {0} table - {1}", tableName, e.Message));
+         }
+
+         try
+         {
+            DataColumnCollection dataColumns;
+
+            // rename the dispense columns to match the note type columns
+            DataRow[] dataRows = dTableSet.Tables["Summary"].Select();
+            foreach (DataRow dataRow in dataRows)
+            {
+               dataColumns = dTableSet.Tables["Dispense"].Columns;
+               foreach (DataColumn dataColumn in dataColumns)
+               {
+                  if (dataColumn.ColumnName == "LU" + dataRow["splcu"].ToString())
+                  {
+                     // the column name is named after a logical unit (e.g. LU1) - rename the column
+                     dataColumn.ColumnName = dataRow["currency"].ToString() + dataRow["denom"].ToString();
+                  }
+               }
+            }
+
+            // delete redundant LUx columns from the dispense table
+            dataColumns = dTableSet.Tables["Dispense"].Columns;
+            List<string> deleteColNames = new List<string>();
+            foreach (DataColumn dataColumn in dataColumns)
+            {
+               if (dataColumn.ColumnName.StartsWith("LU"))
+               {
+                  deleteColNames.Add(dataColumn.ColumnName);
+               }
+            }
+
+            foreach (string colName in deleteColNames)
+            {
+               dTableSet.Tables["Dispense"].Columns.Remove(colName);
+            }
+
+            dTableSet.Tables["Dispense"].AcceptChanges();
+         }
+         catch (Exception e)
+         {
+            ctx.ConsoleWriteLogLine(message: String.Format("Exception processing the {0} table - {1}", tableName, e.Message));
+         }
+
+         try
+         {
+            // C S T L I S T  T A B L E
+
+            tableName = "CSTList";
+
+            try
+            {
+               foreach (DataRow dataRow in dTableSet.Tables[tableName].Rows)
+               {
+                  ctx.ConsoleWriteLogLine(String.Format("notetype : {0} CSTIndex {1}", dataRow["notetype"].ToString(), dataRow["cstindex"].ToString()));
+               }
+
+               // delete the table
+               dTableSet.Tables.Remove(tableName);
+            }
+            catch (Exception e)
+            {
+               ctx.ConsoleWriteLogLine("SETUP_CSTLIST Exception : " + e.Message);
+            }
+
+         }
+         catch (Exception e)
+         {
+            ctx.ConsoleWriteLogLine(message: String.Format("Exception processing the {0} table - {1}", tableName, e.Message));
+         }
+
+         base.PostProcess();
+         return;
+      }
+
+      /// <summary>
+      /// Prep the tables for Excel 
+      /// </summary>
+      /// <returns>true if the write was successful</returns>
+      public override bool WriteExcelFile()
+      {
+         return base.WriteExcelFile();
+      }
+
+
+      /// <summary>
+      /// Process one line from the merged log file. 
+      /// </summary>
+      /// <param name="logLine">logline from the file</param>
+      public override void ProcessRow(ILogLine logLine)
+      {
+         try
+         {
+            if (logLine is APLine apLogLine)
+            {
+               switch (apLogLine.apType)
+               {
+                  /* UPDATE_STATUS */
+
+                  case APLogType.CashDispenser_OnLine:
+                     {
+                        base.ProcessRow(apLogLine);
+                        UPDATE_STATUS(apLogLine, "device", "online");
+                        break;
+                     }
+                  case APLogType.CashDispenser_OffLine:
+                     {
+                        base.ProcessRow(apLogLine);
+                        UPDATE_STATUS(apLogLine, "device", "offline");
+                        break;
+                     }
+                  case APLogType.CashDispenser_OnHWError:
+                     {
+                        base.ProcessRow(apLogLine);
+                        UPDATE_STATUS(apLogLine, "device", "hwerror");
+                        break;
+                     }
+                  case APLogType.CashDispenser_DeviceError:
+                     {
+                        base.ProcessRow(apLogLine);
+                        UPDATE_STATUS(apLogLine, "device", "deverror");
+                        break;
+                     }
+                  case APLogType.CashDispenser_OnDeviceOK:
+                     {
+                        base.ProcessRow(apLogLine);
+                        UPDATE_STATUS(apLogLine, "device", "devok");
+                        break;
+                     }
+                  case APLogType.CashDispenser_NotInPosition:
+                     {
+                        base.ProcessRow(apLogLine);
+                        UPDATE_STATUS(apLogLine, "position", "notinposition");
+                        break;
+                     }
+                  case APLogType.CashDispenser_InPosition:
+                     {
+                        base.ProcessRow(apLogLine);
+                        UPDATE_STATUS(apLogLine, "position", "inposition");
+                        break;
+                     }
+                  case APLogType.CashDispenser_OnNoDispense:
+                     {
+                        base.ProcessRow(apLogLine);
+                        UPDATE_STATUS(apLogLine, "dispenser", "nodispense");
+                        break;
+                     }
+                  case APLogType.CashDispenser_OnDispenserOK:
+                     {
+                        base.ProcessRow(apLogLine);
+                        UPDATE_STATUS(apLogLine, "dispenser", "ok");
+                        break;
+                     }
+                  case APLogType.CashDispenser_OnShutterOpen:
+                     {
+                        base.ProcessRow(apLogLine);
+                        UPDATE_STATUS(apLogLine, "shutter", "open");
+                        break;
+                     }
+                  case APLogType.CashDispenser_OnShutterClosed:
+                     {
+                        base.ProcessRow(apLogLine);
+                        UPDATE_STATUS(apLogLine, "shutter", "closed");
+                        break;
+                     }
+                  case APLogType.CashDispenser_OnStackerNotEmpty:
+                     {
+                        base.ProcessRow(apLogLine);
+                        UPDATE_STATUS(apLogLine, "stacker", "notempty");
+                        break;
+                     }
+                  case APLogType.CashDispenser_OnStackerEmpty:
+                     {
+                        base.ProcessRow(apLogLine);
+                        UPDATE_STATUS(apLogLine, "stacker", "empty");
+                        break;
+                     }
+                  case APLogType.CashDispenser_OnPositionNotEmpty:
+                     {
+                        base.ProcessRow(apLogLine);
+                        UPDATE_STATUS(apLogLine, "posstatus", "notempty");
+                        break;
+                     }
+                  case APLogType.CashDispenser_OnPositionEmpty:
+                     {
+                        base.ProcessRow(apLogLine);
+                        UPDATE_STATUS(apLogLine, "posstatus", "empty");
+                        break;
+                     }
+                  case APLogType.CashDispenser_OnTransportNotEmpty:
+                     {
+                        base.ProcessRow(apLogLine);
+                        UPDATE_STATUS(apLogLine, "transport", "notempty");
+                        break;
+                     }
+                  case APLogType.CashDispenser_OnTransportEmpty:
+                     {
+                        base.ProcessRow(apLogLine);
+                        UPDATE_STATUS(apLogLine, "transport", "empty");
+                        break;
+                     }
+
+                  /* UPDATE DISPENSE */
+
+                  case APLogType.CashDispenser_OnDispenseComplete:
+                     {
+                        base.ProcessRow(apLogLine);
+                        UPDATE_DISPENSE(apLogLine, "position", "dispensed");
+                        break;
+                     }
+                  case APLogType.CashDispenser_OnPresentComplete:
+                     {
+                        base.ProcessRow(apLogLine);
+                        UPDATE_DISPENSE(apLogLine, "position", "presented");
+                        break;
+                     }
+                  case APLogType.CashDispenser_OnRetractComplete:
+                     {
+                        base.ProcessRow(apLogLine);
+                        UPDATE_DISPENSE(apLogLine, "position", "retracted");
+                        break;
+                     }
+                  case APLogType.CashDispenser_OnItemsTaken:
+                     {
+                        base.ProcessRow(apLogLine);
+                        UPDATE_DISPENSE(apLogLine, "position", "itemstaken");
+                        break;
+                     }
+
+                  case APLogType.CashDispenser_OnDenominateComplete:
+                     {
+                        base.ProcessRow(apLogLine);
+                        UPDATE_DISPENSE(apLogLine, "position", "denominated");
+                        break;
+                     }
+                  case APLogType.CashDispenser_ExecDispense:
+                     {
+                        base.ProcessRow(apLogLine);
+                        if (apLogLine is CashDispenser_ExecDispense execDispense)
+                        {
+                           UPDATE_DISPENSE(apLogLine, "hostamount", execDispense.hostAmount);
+                        }
+                        break;
+                     }
+                  case APLogType.CashDispenser_UpdateTypeInfoToDispense:
+                     {
+                        base.ProcessRow(apLogLine);
+                        if (apLogLine is CashDispenser_UpdateTypeInfoToDispense typeInfoToDispense)
+                        {
+                           UPDATE_DISPENSE(apLogLine, "dispensedamount", typeInfoToDispense.dispenseAmount);
+                        }
+                        break;
+                     }
+                  case APLogType.Core_ProcessWithdrawalTransaction_Account:
+                     {
+                        base.ProcessRow(apLogLine);
+                        if (apLogLine is Core_ProcessWithdrawalTransactionAccount wdAccount)
+                        {
+                           UPDATE_DISPENSE(apLogLine, "coreaccount", wdAccount.account);
+                        }
+                        break;
+                     }
+                  case APLogType.Core_DispensedAmount:
+                     {
+                        base.ProcessRow(apLogLine);
+                        if (apLogLine is Core_DispensedAmount dispensedAmount)
+                        {
+                           UPDATE_DISPENSE(apLogLine, "dispensedamount", dispensedAmount.amount);
+                        }
+                        break;
+                     }
+                  case APLogType.Core_RequiredBillMixList:
+                     {
+                        base.ProcessRow(apLogLine);
+                        if (apLogLine is Core_RequiredBillMixList requiredBillMixList)
+                        {
+                           UPDATE_DISPENSE_BILLMIX(apLogLine, "required", requiredBillMixList.requiredbillmixlist);
+                        }
+                        break;
+                     }
+                  case APLogType.CashDispenser_DispenseSyncAsync:
+                     {
+                        base.ProcessRow(apLogLine);
+                        if (apLogLine is CashDispenser_DispenseSyncAsync dispSync)
+                        {
+                           UPDATE_DISPENSE(dispSync, "", "");
+                        }
+                        break;
+                     }
+
+                  case APLogType.HelperFunctions_GetConfiguredBillMixList:
+                     {
+                        base.ProcessRow(apLogLine);
+                        if (apLogLine is HelperFunctions_GetConfiguredBillMixList billMixList)
+                        {
+                           UPDATE_DISPENSE_BILLMIX(billMixList, "configured", billMixList.configuredbillmixlist);
+                        }
+                        break;
+                     }
+                  case APLogType.HelperFunctions_GetFewestBillMixList:
+                     {
+                        base.ProcessRow(apLogLine);
+                        if (apLogLine is HelperFunctions_GetFewestBillMixList billMixList)
+                        {
+                           UPDATE_DISPENSE_BILLMIX(billMixList, "fewest", billMixList.fewestbillmixlist);
+                        }
+                        break;
+                     }
+
+                  /* UPDATE SUMMARY */
+
+                  case APLogType.CashDispenser_SetupCSTList:
+                     {
+                        base.ProcessRow(apLogLine);
+                        if (apLogLine is CashDispenser_SetupCSTList setupCSTList)
+                        {
+                           SETUP_CSTLIST(setupCSTList);
+                        }
+                        break;
+                     }
+
+                  case APLogType.CashDispenser_SetupNoteType:
+                     {
+                        base.ProcessRow(apLogLine);
+                        if (apLogLine is CashDispenser_SetupNoteType setupNoteType)
+                        {
+                           SETUP_NOTETYPE(setupNoteType);
+                        }
+                        break;
+                     }
+
+                  default:
+                     break;
+               }
+            }
+         }
+         catch (Exception e)
+         {
+            ctx.LogWriteLine("CDMTable.ProcessRow EXCEPTION:" + e.Message);
+         }
+      }
+
+
+      protected void UPDATE_STATUS(APLine apLogLine, string colName, string newStatus)
+      {
+         try
+         {
+            DataRow dataRow = dTableSet.Tables["Status"].Rows.Add();
+
+            dataRow["file"] = apLogLine.LogFile;
+            dataRow["time"] = apLogLine.Timestamp;
+            dataRow["error"] = apLogLine.HResult;
+
+            dataRow[colName] = newStatus;
+
+            dTableSet.Tables["Status"].AcceptChanges();
+         }
+         catch (Exception e)
+         {
+            ctx.ConsoleWriteLogLine("STATUS_DEVICE Exception : " + e.Message);
+         }
+
+         return;
+      }
+
+      protected void UPDATE_DISPENSE(APLine apLogLine, string colName, string newStatus)
+      {
+         try
+         {
+            DataRow dataRow = dTableSet.Tables["Dispense"].Rows.Add();
+
+            dataRow["file"] = apLogLine.LogFile;
+            dataRow["time"] = apLogLine.Timestamp;
+            dataRow["error"] = apLogLine.HResult;
+
+            if (!string.IsNullOrEmpty(colName))
+            {
+               dataRow[colName] = newStatus;
+            }
+
+            if (apLogLine is CashDispenser_DispenseSyncAsync dispSync)
+            {
+               ctx.ConsoleWriteLogLine(String.Format("UPDATE_DENOMINATED add DispenseSyncAsync"));
+               for (int i = 0; i < dispSync.dispense.Length; i++)
+               {
+                  dataRow["LU" + i.ToString()] = dispSync.dispense[i];
+               }
+            }
+
+            dTableSet.Tables["Dispense"].AcceptChanges();
+         }
+         catch (Exception e)
+         {
+            ctx.ConsoleWriteLogLine("UPDATE_DISPENSE Exception : " + e.Message);
+         }
+
+         return;
+      }
+
+      protected void UPDATE_DISPENSE_BILLMIX(APLine apLogLine, string posValue, string billMixValue)
+      {
+         try
+         {
+            DataRow dataRow = dTableSet.Tables["Dispense"].Rows.Add();
+
+            dataRow["file"] = apLogLine.LogFile;
+            dataRow["time"] = apLogLine.Timestamp;
+            dataRow["error"] = apLogLine.HResult;
+
+            dataRow["position"] = posValue;
+            dataRow["billmix"] = billMixValue;
+
+            dTableSet.Tables["Dispense"].AcceptChanges();
+         }
+         catch (Exception e)
+         {
+            ctx.ConsoleWriteLogLine("UPDATE_DISPENSE Exception : " + e.Message);
+         }
+
+         return;
+      }
+
+      protected void UPDATE_DISPSYNCASYNC(CashDispenser_DispenseSyncAsync dispSync)
+      {
+         try
+         {
+            ctx.ConsoleWriteLogLine(String.Format("UPDATE_DISPSYNCASYNC dispSync.dispense.Length = {0}", dispSync.dispense.Length));
+
+            DataRow dataRow = dTableSet.Tables["Dispense"].Rows.Add();
+
+            dataRow["file"] = dispSync.LogFile;
+            dataRow["time"] = dispSync.Timestamp;
+            dataRow["error"] = dispSync.HResult;
+
+            for (int i = 0; i < dispSync.dispense.Length; i++)
+            {
+               dataRow["LU" + i.ToString()] = dispSync.dispense[i];
+            }
+
+            dTableSet.Tables["Dispense"].AcceptChanges();
+         }
+         catch (Exception e)
+         {
+            ctx.ConsoleWriteLogLine("UPDATE_DISPENSE Exception : " + e.Message);
+         }
+
+         return;
+      }
+
+      protected void UPDATE_LDC(CashDispenser_GetLCULastDispensedCount lastDispensedCount)
+      {
+         try
+         {
+            if (lastDispensedCount.noteType == "A")
+            {
+               m_lcuRow = dTableSet.Tables["Dispense"].Rows.Add();
+            }
+
+            m_lcuRow["file"] = lastDispensedCount.LogFile;
+            m_lcuRow["time"] = lastDispensedCount.Timestamp;
+            m_lcuRow["error"] = lastDispensedCount.HResult;
+
+            m_lcuRow["position"] = "lastdispense";
+
+            m_lcuRow[lastDispensedCount.noteType] = lastDispensedCount.amount;
+
+            dTableSet.Tables["Dispense"].AcceptChanges();
+
+         }
+         catch (Exception e)
+         {
+            ctx.ConsoleWriteLogLine("UPDATE_DISPENSE Exception : " + e.Message);
+         }
+
+         return;
+      }
+
+      protected void SETUP_CSTLIST(CashDispenser_SetupCSTList setupCSTList)
+      {
+         try
+         {
+            foreach (DataRow dataRow in dTableSet.Tables["CSTList"].Rows)
+            {
+               if (dataRow["notetype"].ToString() == setupCSTList.parent)
+               {
+                  if (dataRow["cstindex"].ToString().IndexOf(setupCSTList.child) == -1)
+                  {
+                     ctx.ConsoleWriteLogLine(String.Format("Before Update - dataRow[notetype] = {0}, dataRow[cstindex] = {1}", dataRow["notetype"].ToString(), dataRow["cstindex"].ToString()));
+                     dataRow["cstindex"] = dataRow["cstindex"].ToString() + setupCSTList.child + " ";
+                     ctx.ConsoleWriteLogLine(String.Format("After  Update - dataRow[notetype] = {0}, dataRow[cstindex] = {1}", dataRow["notetype"].ToString(), dataRow["cstindex"].ToString()));
+                     dTableSet.Tables["CSTList"].AcceptChanges();
+                  }
+                  break;
+               }
+            }
+         }
+         catch (Exception e)
+         {
+            ctx.ConsoleWriteLogLine("SETUP_CSTLIST Exception : " + e.Message);
+         }
+      }
+
+      protected void SETUP_NOTETYPE(CashDispenser_SetupNoteType setupNoteType)
+      {
+         try
+         {
+            foreach (DataRow dataRow in dTableSet.Tables["Summary"].Rows)
+            {
+               if (dataRow["name"].ToString() == setupNoteType.noteType)
+               {
+                  dataRow["file"] = setupNoteType.LogFile;
+                  dataRow["time"] = setupNoteType.Timestamp;
+                  dataRow["error"] = setupNoteType.HResult;
+
+                  dataRow["name"] = setupNoteType.noteType;
+                  dataRow["currency"] = setupNoteType.currency;
+                  dataRow["denom"] = setupNoteType.value;
+                  dataRow["splcu"] = setupNoteType.splcu;
+                  dataRow["sppcu"] = setupNoteType.sppcu;
+
+                  dTableSet.Tables["Summary"].AcceptChanges();
+                  break;
+               }
+            }
+         }
+         catch (Exception e)
+         {
+            ctx.ConsoleWriteLogLine("SETUP_CSTLIST Exception : " + e.Message);
+         }
+      }
+   }
+}
+

--- a/src/CashDispView/CashDispView.cs
+++ b/src/CashDispView/CashDispView.cs
@@ -1,0 +1,24 @@
+﻿using Contract;
+using Impl;
+using System.ComponentModel.Composition;
+
+namespace CashDispView
+{
+   [Export(typeof(IView))]
+   public class CashDispView : BaseView, IView
+   {
+      CashDispView() : base(ParseType.AP, "DispView") { }
+
+      /// <summary>
+      /// Creates an CD Table instance. 
+      /// </summary>
+      /// <param name="ctx">Context for the command. </param>
+      /// <returns>new HCDU table</returns>
+      protected override BaseTable CreateTableInstance(IContext ctx)
+      {
+         CashDispTable ejTable = new CashDispTable(ctx, viewName);
+         ejTable.ReadXmlFile();
+         return ejTable;
+      }
+   }
+}

--- a/src/CashDispView/CashDispView.csproj
+++ b/src/CashDispView/CashDispView.csproj
@@ -4,11 +4,11 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{79FE7807-0694-473C-8DD5-7D7013E14EDF}</ProjectGuid>
+    <ProjectGuid>{6A17B223-75D7-4C38-A30B-0EC11D237372}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>APLine</RootNamespace>
-    <AssemblyName>APLine</AssemblyName>
+    <RootNamespace>CashDispView</RootNamespace>
+    <AssemblyName>CashDispView</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
@@ -32,6 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -41,58 +42,36 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AddKey.cs" />
-    <Compile Include="APLine.cs" />
-    <Compile Include="CashDispenser\CashDispener.cs" />
-    <Compile Include="CashDispenser\CashDispenser_DispenseSyncAsync.cs" />
-    <Compile Include="CashDispenser\CashDispenser_ExecDispense.cs" />
-    <Compile Include="CashDispenser\CashDispenser_GetLCULastDispensedCount.cs" />
-    <Compile Include="CashDispenser\CashDispenser_Open.cs" />
-    <Compile Include="CashDispenser\CashDispenser_SetupCSTList.cs" />
-    <Compile Include="CashDispenser\CashDispenser_SetupNoteType.cs" />
-    <Compile Include="CashDispenser\CashDispenser_UpdateTypeInfoToDispense.cs" />
-    <Compile Include="CommFrmWork.cs" />
-    <Compile Include="Core\Core.cs" />
-    <Compile Include="Core\Core_ProcessWithdrawalTransactionAccount.cs" />
-    <Compile Include="Core\Core_DispensedAmount.cs" />
-    <Compile Include="Core\Core_RequiredBillMixList.cs" />
-    <Compile Include="Core\Core_ProcessWithdrawalTransactionAmount.cs" />
-    <Compile Include="DevUnSolEvent.cs" />
-    <Compile Include="EJInsert.cs" />
-    <Compile Include="FnKey.cs" />
-    <Compile Include="HelperFunctions\HelperFunctions.cs" />
-    <Compile Include="HelperFunctions\HelperFunctions_GetConfiguredBillMixList.cs" />
-    <Compile Include="HelperFunctions\HelperFunctions_GetFewestBillMixList.cs" />
-    <Compile Include="HlpBillMix.cs" />
-    <Compile Include="NDC\Atm2Host\Atm2Host.cs" />
-    <Compile Include="NDC\Atm2Host\Atm2Host11.cs" />
-    <Compile Include="NDC\Host2Atm\Host2Atm.cs" />
-    <Compile Include="NDC\Host2Atm\Host2Atm1.cs" />
-    <Compile Include="NDC\NDC.cs" />
-    <Compile Include="Pinpad.cs" />
-    <Compile Include="PANData.cs" />
+    <Compile Include="CashDispTable.cs" />
+    <Compile Include="CashDispView.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="CreateNextState.cs" />
-    <Compile Include="ScreenName.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\APSamplesTests\APSamples.csproj">
-      <Project>{98624250-55f4-407e-9a99-242690d17f0f}</Project>
-      <Name>APSamples</Name>
+    <ProjectReference Include="..\APLine\APLogLine.csproj">
+      <Project>{79fe7807-0694-473c-8dd5-7d7013e14edf}</Project>
+      <Name>APLogLine</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\BaseView\BaseView.csproj">
+      <Project>{db43982d-e960-4dba-83ef-1bb6e7a60a49}</Project>
+      <Name>BaseView</Name>
     </ProjectReference>
     <ProjectReference Include="..\Contract\Contract.csproj">
       <Project>{9ef4286e-dc11-479c-84a0-eb43a70e1bde}</Project>
       <Name>Contract</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Impl\Impl.csproj">
+      <Project>{f89403e5-4c5c-4d8f-8401-b2d56f6d8a2b}</Project>
+      <Name>Impl</Name>
+    </ProjectReference>
     <ProjectReference Include="..\LogLineHandler\LogLineHandler.csproj">
       <Project>{43796ea3-f9fb-4be0-8730-a9d5b807c9c3}</Project>
       <Name>LogLineHandler</Name>
     </ProjectReference>
-    <ProjectReference Include="..\RegEx\RegEx.csproj">
-      <Project>{08528b3a-39f6-4e08-81fa-9b3c2935316a}</Project>
-      <Name>RegEx</Name>
-    </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>copy "$(MSBuildProjectDirectory)\bin\$(Configuration)\*.dll" $(SolutionDir)\..\dist
+copy "$(MSBuildProjectDirectory)\CashDispView.xsd" $(SolutionDir)\..\dist
+copy "$(MSBuildProjectDirectory)\CashDispView.xml" $(SolutionDir)\..\dist</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/src/CashDispView/CashDispView.xml
+++ b/src/CashDispView/CashDispView.xml
@@ -1,0 +1,185 @@
+<?xml version="1.0" standalone="yes"?>
+<CashDisp>
+
+  <Summary>
+    <file></file>
+    <time></time>
+    <error></error>
+    <name>A</name>
+    <currency></currency>
+    <denom>-1</denom>
+    <splcu>-1</splcu>
+    <sppcu>-1</sppcu>
+    <cindex></cindex>
+    <comment></comment>
+  </Summary>
+
+  <Summary>
+    <file></file>
+    <time></time>
+    <error></error>
+    <name>B</name>
+    <currency></currency>
+    <denom>-1</denom>
+    <splcu>-1</splcu>
+    <sppcu>-1</sppcu>
+    <cindex></cindex>
+    <comment></comment>
+  </Summary>
+  
+  <Summary>
+    <file></file>
+    <time></time>
+    <error></error>
+    <name>C</name>
+    <currency></currency>
+    <denom>-1</denom>
+    <splcu>-1</splcu>
+    <sppcu>-1</sppcu>
+    <cindex></cindex>
+    <comment></comment>
+  </Summary>
+
+  <Summary>
+    <file></file>
+    <time></time>
+    <error></error>
+    <name>D</name>
+    <currency></currency>
+    <denom>-1</denom>
+    <splcu>-1</splcu>
+    <sppcu>-1</sppcu>
+    <cindex></cindex>
+    <comment></comment>
+  </Summary>
+  
+  <Summary>
+    <file></file>
+    <time></time>
+    <error></error>
+    <name>E</name>
+    <currency></currency>
+    <denom>-1</denom>
+    <splcu>-1</splcu>
+    <sppcu>-1</sppcu>
+    <cindex></cindex>
+    <comment></comment>
+  </Summary>
+  
+  <Summary>
+    <file></file>
+    <time></time>
+    <error></error>
+    <name>F</name>
+    <currency></currency>
+    <denom>-1</denom>
+    <splcu>-1</splcu>
+    <sppcu>-1</sppcu>
+    <cindex></cindex>
+    <comment></comment>
+  </Summary>
+  
+  <Summary>
+    <file></file>
+    <time></time>
+    <error></error>
+    <name>G</name>
+    <currency></currency>
+    <denom>-1</denom>
+    <splcu>-1</splcu>
+    <sppcu>-1</sppcu>
+    <cindex></cindex>
+    <comment></comment>
+  </Summary>
+  
+  <Summary>
+    <file></file>
+    <time></time>
+    <error></error>
+    <name>H</name>
+    <currency></currency>
+    <denom>-1</denom>
+    <splcu>-1</splcu>
+    <sppcu>-1</sppcu>
+    <cindex></cindex>
+    <comment></comment>
+  </Summary>
+  
+  <Summary>
+    <file></file>
+    <time></time>
+    <error></error>
+    <name>I</name>
+    <currency></currency>
+    <denom>-1</denom>
+    <splcu>-1</splcu>
+    <sppcu>-1</sppcu>
+    <cindex></cindex>
+    <comment></comment>
+  </Summary>
+
+  <Summary>
+    <file></file>
+    <time></time>
+    <error></error>
+    <name>J</name>
+    <currency></currency>
+    <denom>-1</denom>
+    <splcu>-1</splcu>
+    <sppcu>-1</sppcu>
+    <cindex></cindex>
+    <comment></comment>
+  </Summary>
+  
+  <CSTList>
+    <notetype>A</notetype>
+    <cstindex></cstindex>
+  </CSTList>
+
+  <CSTList>
+    <notetype>B</notetype>
+    <cstindex></cstindex>
+  </CSTList>
+  
+  <CSTList>
+    <notetype>C</notetype>
+    <cstindex></cstindex>
+  </CSTList>
+  
+  <CSTList>
+    <notetype>D</notetype>
+    <cstindex></cstindex>
+  </CSTList>
+
+  <CSTList>
+    <notetype>E</notetype>
+    <cstindex></cstindex>
+  </CSTList>
+  
+  <CSTList>
+    <notetype>F</notetype>
+    <cstindex></cstindex>
+  </CSTList>
+  
+  <CSTList>
+    <notetype>G</notetype>
+    <cstindex></cstindex>
+  </CSTList>
+  
+  <CSTList>
+    <notetype>H</notetype>
+    <cstindex></cstindex>
+  </CSTList>
+  
+  <CSTList>
+    <notetype>I</notetype>
+    <cstindex></cstindex>
+  </CSTList>
+
+  <CSTList>
+    <notetype>J</notetype>
+    <cstindex></cstindex>
+  </CSTList>
+
+  
+</CashDisp>

--- a/src/CashDispView/CashDispView.xsd
+++ b/src/CashDispView/CashDispView.xsd
@@ -1,0 +1,75 @@
+<?xml version="1.0" standalone="yes"?>
+<xs:schema id="CashDisp" xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+  <xs:element name="CashDisp" msdata:IsDataSet="true" msdata:UseCurrentLocale="true">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="Status">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="file" type="xs:string" minOccurs="0" />
+              <xs:element name="time" type="xs:string" minOccurs="0" />
+              <xs:element name="error" type="xs:string" minOccurs="0" />
+              <xs:element name="device" type="xs:string" minOccurs="0" />
+              <xs:element name="position" type="xs:string" minOccurs="0" />
+              <xs:element name="dispenser" type="xs:string" minOccurs="0" />
+              <xs:element name="shutter" type="xs:string" minOccurs="0" />
+              <xs:element name="stacker" type="xs:string" minOccurs="0" />
+              <xs:element name="posstatus" type="xs:string" minOccurs="0" />
+              <xs:element name="transport" type="xs:string" minOccurs="0" />
+              <xs:element name="comment" type="xs:string" minOccurs="0" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="Dispense">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="file" type="xs:string" minOccurs="0" />
+              <xs:element name="time" type="xs:string" minOccurs="0" />
+              <xs:element name="error" type="xs:string" minOccurs="0" />
+              <xs:element name="position" type="xs:string" minOccurs="0" />
+              <xs:element name="hostamount" type="xs:string" minOccurs="0" />
+              <xs:element name="coreaccount" type="xs:string" minOccurs="0" />
+              <xs:element name="billmix" type="xs:string" minOccurs="0" />
+              <xs:element name="dispensedamount" type="xs:string" minOccurs="0" />
+              <xs:element name="LU0" type="xs:string" minOccurs="0" />
+              <xs:element name="LU1" type="xs:string" minOccurs="0" />
+              <xs:element name="LU2" type="xs:string" minOccurs="0" />
+              <xs:element name="LU3" type="xs:string" minOccurs="0" />
+              <xs:element name="LU4" type="xs:string" minOccurs="0" />
+              <xs:element name="LU5" type="xs:string" minOccurs="0" />
+              <xs:element name="LU6" type="xs:string" minOccurs="0" />
+              <xs:element name="LU7" type="xs:string" minOccurs="0" />
+              <xs:element name="LU8" type="xs:string" minOccurs="0" />
+              <xs:element name="LU9" type="xs:string" minOccurs="0" />
+              <xs:element name="comment" type="xs:string" minOccurs="0" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="Summary">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="file" type="xs:string" minOccurs="0" />
+              <xs:element name="time" type="xs:string" minOccurs="0" />
+              <xs:element name="error" type="xs:string" minOccurs="0" />
+              <xs:element name="name" type="xs:string" minOccurs="0" />
+              <xs:element name="currency" type="xs:string" minOccurs="0" />
+              <xs:element name="denom" type="xs:string" minOccurs="0" />
+              <xs:element name="splcu" type="xs:string" minOccurs="0" />
+              <xs:element name="sppcu" type="xs:string" minOccurs="0" />
+              <xs:element name="cindex" type="xs:string" minOccurs="0" />
+              <xs:element name="comment" type="xs:string" minOccurs="0" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="CSTList">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="notetype" type="xs:string" minOccurs="0" />
+              <xs:element name="cstindex" type="xs:string" minOccurs="0" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/CashDispView/Properties/AssemblyInfo.cs
+++ b/src/CashDispView/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("CashDispView")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("CashDispView")]
+[assembly: AssemblyCopyright("Copyright ©  2023")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("6a17b223-75d7-4c38-a30b-0ec11d237372")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Contract/ILogFileHandler.cs
+++ b/src/Contract/ILogFileHandler.cs
@@ -2,6 +2,7 @@
 {
    public interface ILogFileHandler
    {
+      IContext ctx { get; set; }
       string Name { get; }
       bool Initialize(IContext ctx);
       string[] FilesFound { get; set; }

--- a/src/LogFileHandler/APLogHandler.cs
+++ b/src/LogFileHandler/APLogHandler.cs
@@ -94,85 +94,6 @@ namespace LogFileHandler
          if (logLine.StartsWith("=======") && logLine.EndsWith("========\r\n"))
             return new APLine(this, logLine, APLogType.APLOG_INSTALL);
 
-         ///* APLOG_SETTINGS */
-         //if (logLine.Contains("[ConfigurationFramework") && logLine.Contains("ProcessXMLFiles") && logLine.Contains("Adding xml file:"))
-         //   return new APLine(this, logLine, APLogType.APLOG_SETTINGS_CONFIG);
-
-         ///* APLOG_FLW_CURRENTMODE */
-         //if (logLine.Contains("Current Mode:"))
-         //   return new APLine(this, logLine, APLogType.APLOG_FLW_CURRENTMODE);
-
-         ///* DEV_UNSOL_EVENT */
-         //if (logLine.Contains("[RaiseDeviceUnSolEvent") && logLine.Contains("FireDeviceUnsolEvent"))
-         //   return new DevUnSolEvent(this, logLine);
-
-         ///* APLOG_FLW_CARD_PAN */
-         //if (logLine.Contains("[NCompleteICCAppSelectState") && logLine.Contains("[SetTrackData") && logLine.Contains("Device.CardReader.PANData"))
-         //   return new PANData(this, logLine);
-
-         ///* APLOG_FLW_SWITCH_FIT */
-         //if (logLine.Contains("[FITSwitchState") && logLine.Contains("ExecuteState") && logLine.Contains("Next State is to be "))
-         //   return new APLine(this, logLine, APLogType.APLOG_FLW_SWITCH_FIT);
-
-         ///* COMM_FRMWORK */
-         //if (logLine.Contains("[CommunicationFramework") && logLine.Contains("OnConnectedHost") && logLine.Contains("Host Connected") ||
-         //    logLine.Contains("[CommunicationFramework") && logLine.Contains("OnDisconnectedHost") && logLine.Contains("Host disconnected"))
-         //   return new CommFrmWork(this, logLine);
-
-         ///* PINPAD */
-         //if (logLine.Contains("[Pinpad") && logLine.Contains("OnReadPinComplete"))
-         //   return new Pinpad(this, logLine);
-
-         ///* PINPAD */
-         //if (logLine.Contains("[Pinpad") && logLine.Contains("OnPinBlockComplete"))
-         //   return new Pinpad(this, logLine);
-
-         ///* APLOG_FLW_PINBLOCK_FAILED */
-         //if (logLine.Contains("[PinEntryState") && logLine.Contains("[ProcessBuildPINBlock") && logLine.Contains("BuildPINBlock failed"))
-         //   return new APLine(this, logLine, APLogType.APLOG_FLW_PINBLOCK_FAILED);
-
-         /////* APLOG_FLW_SCREEN */
-         ////if (logLine.Contains("[ShowScreenCore") && logLine.Contains("ShowScreenCore pScreenNumber"))
-         ////   return new APLine(this, logLine, APLogType.APLOG_FLW_SCREEN);
-
-         ///* APLOG_FLW_SCREEN_NAME */
-         //if (logLine.Contains("[LocalScreenWindowEx") && logLine.Contains("[ProcessPageRequest"))
-         //   return new ScreenName(this, logLine);
-
-         ///* APLOG_FLW_STATE */
-         //if (logLine.Contains("[HybridFlowEngine") && logLine.Contains("CreateNextState") && logLine.Contains("State created: "))
-         //   return new CreateNextState(this, logLine);
-
-         ///* APLOG_FLW_FUNCTIONKEY */
-         ///* OLD [ScreenDecoratorLocal][OnFunctionKeySelected][NORMAL]Raising FunctionKeySelected event with values FunctionKey[No], PinInputData[], ResultData[]. */
-         //if (logLine.Contains("[ScreenDecoratorLocal") && logLine.Contains("[OnFunctionKeySelected") && logLine.Contains("Raising FunctionKeySelected event with values FunctionKey"))
-         //   return new FnKey(this, logLine);
-
-         ///* APLOG_FLW_FUNCTIONKEY */
-         ///* NEW [ScreenDecoratorLocal.OnFunctionKeySelected] The No button was pressed.*/
-         //if (logLine.Contains("[ScreenDecoratorLocal.OnFunctionKeySelected]"))
-         //   return new APLine(this, logLine, APLogType.APLOG_FLW_FUNCTIONKEY2);
-
-         ///* APLOG_FLW_DEVICE_FITNESS */
-         //if (logLine.Contains("[GetDeviceFitness") && logLine.Contains("Parameter pDvcStatus:"))
-         //   return new APLine(this, logLine, APLogType.APLOG_FLW_DEVICE_FITNESS);
-
-
-         ///* APLOG_WD */
-
-         /////* APLOG_WD_WITHDRAW */
-         ////if (logLine.Contains("Raising FunctionKeySelected event with values FunctionKey[Withdrawal]"))
-         ////   return new APLine(this, logLine, APLogType.APLOG_WD_WITHDRAW);
-
-         ///* HLPR_BILLMIX */
-         //if (logLine.Contains("[HelperFunctions") && logLine.Contains("SetBufferWithBillMix") && logLine.Contains("Using BillMixList:"))
-         //   return new HlpBillMix(this, logLine);
-
-         /////* APLOG_WD_EMVAMOUNT */
-         ////if (logLine.Contains("ExecuteState") && logLine.Contains("EMVState.Amount"))
-         ////   return new APLine(this, logLine, APLogType.APLOG_WD_EMVAMOUNT);
-
-
          /* AddKey */
          if (logLine.Contains("[AbstractConfigHandler") && logLine.Contains("AddMoniplusData") && logLine.Contains("Add Key="))
             return new AddKey(this, logLine);
@@ -184,77 +105,36 @@ namespace LogFileHandler
             if (iLine != null) return iLine;
          }
 
+         ///* NDC */
+         //if (logLine.Contains("[RecvProcAsync") && logLine.Contains("HOST2ATM:"))
+         //{
+         //   ILogLine iLine = Host2Atm.Factory(this, logLine);
+         //   if (iLine != null) return iLine;
+         //}
+
+         //if (logLine.Contains("[RecvProcAsync") && logLine.Contains("ATM2HOST:"))
+         //{
+         //   ILogLine iLine = Atm2Host.Factory(this, logLine);
+         //   if (iLine != null) return iLine;
+         //}
+
+         /* CORE */
+         if (logLine.Contains("WebServiceRequestFlowPoint"))
+         {
+            ILogLine iLine = Core.Factory(this, logLine);
+            if (iLine != null) return iLine;
+         }
+
          /* EJ */
          if (logLine.Contains("INSERT INTO "))
             return new EJInsert(this, logLine);
 
-         //if (logLine.Contains("UpdateTypeInfoToDispense") && logLine.Contains("Dispensing amount in total is "))
-         //   return new APLine(this, logLine, APLogType.APLOG_WD_DISPENSE);
-
-         ///* APLOG_WD_PRESENTED */
-         //if (logLine.Contains("CashDispenser_Prensented") && logLine.Contains("Present compete event, EventType=CashPresented"))
-         //   return new APLine(this, logLine, APLogType.APLOG_WD_PRESENTED);
-
-         ///* APLOG_WD_ITEMSTAKEN */
-         //if (logLine.Contains("OnItemsTaken") && logLine.Contains("m_NxCashDispenser.OnItemsTaken event received"))
-         //   return new APLine(this, logLine, APLogType.APLOG_WD_ITEMSTAKEN);
-
-         //if (logLine.Contains("SetupCSTListInHostTypeInfo"))
-         //   return new APLine(this, logLine, APLogType.APLOG_WD_SETUPCSTLISTINHOST);
-
-         //if (logLine.Contains("SetupNoteTypeInfo") && logLine.Contains("Set NoteType"))
-         //   return new APLine(this, logLine, APLogType.APLOG_WD_SETUPNOTETYPEINFO);
-
-
-
-         ///* ADLOG_NDC */
-         //if (logLine.Contains("Send") && logLine.Contains("ATM2HOST:"))
-         //   return new APLine(this, logLine, APLogType.APLOG_NDC_ATM2HOST);
-         ///*
-         //         if (logLine.Contains("Send") && logLine.Contains("ATM2HOST: 12"))
-         //            return (APLogType.APLOG_NDC_ATM2HOST12, logLine);
-
-         //         if (logLine.Contains("Send") && logLine.Contains("ATM2HOST: 22"))
-         //            return (APLogType.APLOG_NDC_ATM2HOST22, logLine);
-
-         //         if (logLine.Contains("Send") && logLine.Contains("ATM2HOST: 23"))
-         //            return (APLogType.APLOG_NDC_ATM2HOST23, logLine);
-
-         //         if (logLine.Contains("Send") && logLine.Contains("ATM2HOST: 51"))
-         //            return (APLogType.APLOG_NDC_ATM2HOST51, logLine);
-
-         //         if (logLine.Contains("Send") && logLine.Contains("ATM2HOST: 61"))
-         //            return (APLogType.APLOG_NDC_ATM2HOST51, logLine);
-
-         //         if (logLine.Contains("Send") && logLine.Contains("ATM2HOST:"))
-         //            return (APLogType.APLOG_NDC_ATM2HOST, logLine);
-         //*/
-         //if (logLine.Contains("RecvProcAsync") && logLine.Contains("HOST2ATM:"))
-         //   return new APLine(this, logLine, APLogType.APLOG_NDC_HOST2ATM);
-         ///*
-         //         if (logLine.Contains("RecvProcAsync") && logLine.Contains("HOST2ATM: 3"))
-         //            return (APLogType.APLOG_NDC_HOST2ATM3, logLine);
-
-         //         if (logLine.Contains("RecvProcAsync") && logLine.Contains("HOST2ATM: 4"))
-         //            return (APLogType.APLOG_NDC_HOST2ATM4, logLine);
-
-         //         if (logLine.Contains("RecvProcAsync") && logLine.Contains("HOST2ATM: 7"))
-         //            return (APLogType.APLOG_NDC_HOST2ATM7, logLine);
-
-         //         if (logLine.Contains("RecvProcAsync") && logLine.Contains("HOST2ATM:"))
-         //            return (APLogType.APLOG_NDC_HOST2ATM, logLine);
-         //*/
-
-         ///* APLOG_MEMORY */
-         //if (logLine.Contains("MemoryWatchDog") && logLine.Contains("UsedProcessMemory  :"))
-         //   return new APLine(this, logLine, APLogType.APLOG_MEMORY);
-
-         ///* OPERATOR */
-         //if (logLine.Contains("[NavigateOPMenu") && logLine.Contains("Parameter pMenuName:"))
-         //   return new APLine(this, logLine, APLogType.APLOG_OPER_MENUNAME);
-
-         //if (logLine.Contains("m_NxDoors.OnDoorChanged event received"))
-         //   return new APLine(this, logLine, APLogType.APLOG_OPER_DOOR);
+         /* HELPER FUNCTIONS */
+         if (logLine.Contains("[HelperFunctions"))
+         {
+            ILogLine iLine = HelperFunctions.Factory(this, logLine);
+            if (iLine != null) return iLine;
+         }
 
          return new APLine(this, logLine, APLogType.None);
       }

--- a/src/LogFileHandler/LogHandler.cs
+++ b/src/LogFileHandler/LogHandler.cs
@@ -1,11 +1,11 @@
 ﻿using System.IO;
-using Contract; 
+using Contract;
 
 namespace LogFileHandler
 {
-    public class LogHandler
-    {
-      protected IContext ctx;
+   public class LogHandler
+   {
+      public IContext ctx { get; set; }
       protected ICreateStreamReader createReader;
 
       public ParseType parseType { get; }
@@ -26,7 +26,7 @@ namespace LogFileHandler
       public string[] FilesFound { get; set; }
 
       // file name
-      public string fileName; 
+      public string fileName;
 
       // entire log file
       protected char[] logFile;
@@ -38,14 +38,14 @@ namespace LogFileHandler
 
       public LogHandler(ParseType parseType, ICreateStreamReader createReader)
       {
-         this.parseType = parseType; 
-         this.createReader = createReader; 
+         this.parseType = parseType;
+         this.createReader = createReader;
       }
 
       public bool Initialize(IContext ctx)
       {
          // find all files
-         this.ctx = ctx; 
+         this.ctx = ctx;
          FilesFound = ctx.ioProvider.GetFiles(ctx.WorkFolder + "\\" + ctx.SubFolder, LogExpression);
          return FilesFound.Length > 0;
       }

--- a/src/splogparser.sln
+++ b/src/splogparser.sln
@@ -76,6 +76,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "APSamples", "APSamples", "{
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "APSamples", "APSamplesTests\APSamples.csproj", "{98624250-55F4-407E-9A99-242690D17F0F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CashDispView", "CashDispView\CashDispView.csproj", "{6A17B223-75D7-4C38-A30B-0EC11D237372}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -182,6 +184,10 @@ Global
 		{98624250-55F4-407E-9A99-242690D17F0F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{98624250-55F4-407E-9A99-242690D17F0F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{98624250-55F4-407E-9A99-242690D17F0F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A17B223-75D7-4C38-A30B-0EC11D237372}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A17B223-75D7-4C38-A30B-0EC11D237372}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A17B223-75D7-4C38-A30B-0EC11D237372}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A17B223-75D7-4C38-A30B-0EC11D237372}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -211,6 +217,7 @@ Global
 		{93BD0130-63C0-4873-834A-CE986F9AB32E} = {8EC4E5B2-01E8-4DE9-A7AE-2685B29B4F7F}
 		{15BFBC23-2F67-4329-A83E-1710DDABCAC9} = {8EC4E5B2-01E8-4DE9-A7AE-2685B29B4F7F}
 		{98624250-55F4-407E-9A99-242690D17F0F} = {15BFBC23-2F67-4329-A83E-1710DDABCAC9}
+		{6A17B223-75D7-4C38-A30B-0EC11D237372} = {BDCD7A03-828B-44E6-9169-223946D1BBC9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2E3C1D19-CB84-47CD-B2F7-F495926D01C3}


### PR DESCRIPTION
Added AP logline parsing for Cash Dispense log lines to create a first cut Cash Dispense View. This involved adding CashDispenser, HelperFunction and Core log lines. Exposed the ctx through the ILogFileHandler interface so we can log from within factory methods.