### PR TITLE
Fix: Added pre-analyze, analyze, and-post-analyze Steps

### DIFF
--- a/src/CashDispView/DispTable.cs
+++ b/src/CashDispView/DispTable.cs
@@ -121,13 +121,22 @@ namespace CashDispView
 
             try
             {
-               foreach (DataRow dataRow in dTableSet.Tables[tableName].Rows)
+               foreach (DataRow cstListRow in dTableSet.Tables[tableName].Rows)
                {
-                  ctx.ConsoleWriteLogLine(String.Format("notetype : {0} CSTIndex {1}", dataRow["notetype"].ToString(), dataRow["cstindex"].ToString()));
+                  foreach (DataRow summaryRow in dTableSet.Tables["Summary"].Rows)
+                  {
+                     if (summaryRow["name"].ToString() == cstListRow["notetype"].ToString())
+                     {
+                        summaryRow["cindex"] = cstListRow["cstindex"].ToString();
+                     }
+                  }
+                  ctx.ConsoleWriteLogLine(String.Format("notetype : {0} CSTIndex {1}", cstListRow["notetype"].ToString(), cstListRow["cstindex"].ToString()));
                }
 
                // delete the table
                dTableSet.Tables.Remove(tableName);
+               dTableSet.AcceptChanges();
+
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Modified the parser lifecycle to include pre-analyze, analyze and post-analyze steps. This allows views to work on data post timeseries, even across views. Changed the name of CashDispView to DispView because the name length was too long. Added cindex to Disp Summary (physical cassette mapping to logical cassettes)