### PR TITLE
Fix: Upated AP Log Parsing

### DIFF
--- a/src/OverView/OverTable.cs
+++ b/src/OverView/OverTable.cs
@@ -555,7 +555,7 @@ namespace OverView
                         if (apLogLine is APLineField)
                         {
                            APLineField lineField = (APLineField)apLogLine;
-                           APLINE(lineField, "operator menu", lineField.field);
+                           APLINE(lineField, "operatormenu", lineField.field);
                         }
                         break;
                      }

--- a/src/OverView/OverView.xsd
+++ b/src/OverView/OverView.xsd
@@ -21,7 +21,7 @@
               <xs:element name="functionkey" type="xs:string" minOccurs="0" />
               <xs:element name="dispensed" type="xs:string" minOccurs="0" />
               <xs:element name="account" type="xs:string" minOccurs="0" />
-              <xs:element name="operator menu" type="xs:string" minOccurs="0" />
+              <xs:element name="operatormenu" type="xs:string" minOccurs="0" />
               <xs:element name="comment" type="xs:string" minOccurs="0" />
             </xs:sequence>
           </xs:complexType>


### PR DESCRIPTION
Moved the Factory method into the APLine class and injected the APLine.Factory into APLogLineHandler. This decouples file reading from log line parsing. Updated the OverView view to include RFID message parsing.