### PR TITLE
Fix: Upated AP Log Parsing

### DIFF
--- a/src/APLine/APLine.cs
+++ b/src/APLine/APLine.cs
@@ -69,6 +69,7 @@ namespace LogLineHandler
 
       APLOG_DISPLAYLOAD,
       APLOG_SCREENWINDOW, 
+      APLOG_KEYPRESS,
 
       APLOG_LOCALXMLHELPER_ABOUT_TO_EXECUTE,
 
@@ -397,25 +398,25 @@ namespace LogLineHandler
 
 
          /* [Pinpad              */
-         if (logLine.Contains("[Pinpad") && logLine.Contains("[Open"))
+         if (logLine.Contains("[Pinpad") && logLine.Contains("Open"))
             return new APLine(logFileHandler, logLine, APLogType.APLOG_PIN_OPEN);
 
-         if (logLine.Contains("[Pinpad") && logLine.Contains("[Close"))
+         if (logLine.Contains("[Pinpad") && logLine.Contains("Close"))
             return new APLine(logFileHandler, logLine, APLogType.APLOG_PIN_CLOSE);
 
-         if (logLine.Contains("[Pinpad") && logLine.Contains("[CheckTheEppIsPci"))
+         if (logLine.Contains("[Pinpad") && logLine.Contains("CheckTheEppIsPci"))
             return new APLineField(logFileHandler, logLine, APLogType.APLOG_PIN_ISPCI);
 
-         if (logLine.Contains("[Pinpad") && logLine.Contains("[CheckTheEppSupportTR31"))
+         if (logLine.Contains("[Pinpad") && logLine.Contains("CheckTheEppSupportTR31"))
             return new APLineField(logFileHandler, logLine, APLogType.APLOG_PIN_ISTR31);
 
-         if (logLine.Contains("[Pinpad") && logLine.Contains("[CheckTheEppSupportTR34"))
+         if (logLine.Contains("[Pinpad") && logLine.Contains("CheckTheEppSupportTR34"))
             return new APLineField(logFileHandler, logLine, APLogType.APLOG_PIN_ISTR34);
 
-         if (logLine.Contains("[Pinpad") && logLine.Contains("[OnKeyImported"))
+         if (logLine.Contains("[Pinpad") && logLine.Contains("OnKeyImported"))
             return new APLine(logFileHandler, logLine, APLogType.APLOG_PIN_KEYIMPORTED);
 
-         if (logLine.Contains("[Pinpad") && logLine.Contains("[OnRandomNumberGenerated"))
+         if (logLine.Contains("[Pinpad") && logLine.Contains("OnRandomNumberGenerated"))
             return new APLine(logFileHandler, logLine, APLogType.APLOG_PIN_RAND);
 
          if (logLine.Contains("[Pinpad") && logLine.Contains("OnPinBlockComplete"))
@@ -424,20 +425,22 @@ namespace LogLineHandler
          if (logLine.Contains("[PinEntryState") && logLine.Contains("BuildPINBlock failed"))
             return new APLine(logFileHandler, logLine, APLogType.APLOG_PIN_PINBLOCK_FAILED);
 
-         if (logLine.Contains("[Pinpad") && logLine.Contains("[OnTimeout"))
+         if (logLine.Contains("[Pinpad") && logLine.Contains("OnTimeout"))
             return new APLine(logFileHandler, logLine, APLogType.APLOG_PIN_TIMEOUT);
 
-         if (logLine.Contains("[Pinpad") && logLine.Contains("[OnReadPinComplete"))
+         if (logLine.Contains("[Pinpad") && logLine.Contains("OnReadPinComplete"))
             return new APLine(logFileHandler, logLine, APLogType.APLOG_PIN_READCOMPLETE);
 
 
 
-         if (logLine.Contains("[LocalScreenWindowEx") && logLine.Contains("[DisplayLoadCompleted"))
+         if (logLine.Contains("[LocalScreenWindowEx") && logLine.Contains("DisplayLoadCompleted"))
             return new APLineField(logFileHandler, logLine, APLogType.APLOG_DISPLAYLOAD);
 
          if (logLine.Contains("[ScreenWindow") && logLine.Contains("LogAdditionalInformation"))
             return new APLineField(logFileHandler, logLine, APLogType.APLOG_SCREENWINDOW);
 
+         if (logLine.Contains("[ScreenDecoratorLocal") && logLine.Contains("PinpadKeyPressed"))
+            return new APLine(logFileHandler, logLine, APLogType.APLOG_KEYPRESS);
 
          if (logLine.Contains("[LocalXmlHelper") && logLine.Contains("About to execute: Class: HelperFunctions, Method:"))
             return new APLineField(logFileHandler, logLine, APLogType.APLOG_LOCALXMLHELPER_ABOUT_TO_EXECUTE);

--- a/src/APLogLineTests/APLogHandler_IdentifyLines_Tests.cs
+++ b/src/APLogLineTests/APLogHandler_IdentifyLines_Tests.cs
@@ -426,5 +426,31 @@ namespace APLogLineTests
 
          Assert.IsTrue(apLine.field == "Supervisor");
       }
+
+      [TestMethod]
+      public void APLOG_KEYPRESS()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock(), ParseType.AP, APLine.Factory);
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_general.APLOG_KEYPRESS);
+         Assert.IsTrue(logLine is APLine);
+
+         APLine apLine = (APLine)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.APLOG_KEYPRESS);
+         Assert.IsTrue(apLine.Timestamp == "2024-06-23 17:41:05.937");
+         Assert.IsTrue(apLine.HResult == "");;
+      }
+
+      [TestMethod]
+      public void APLOG_KEYPRESS_1()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock(), ParseType.AP, APLine.Factory);
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_general.APLOG_KEYPRESS_1);
+         Assert.IsTrue(logLine is APLine);
+
+         APLine apLine = (APLine)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.APLOG_KEYPRESS);
+         Assert.IsTrue(apLine.Timestamp == "2024-09-05 03:15:16.644");
+         Assert.IsTrue(apLine.HResult == "");
+      }
    }
 }

--- a/src/APSamplesTests/samples_general.cs
+++ b/src/APSamplesTests/samples_general.cs
@@ -173,6 +173,13 @@ namespace APSamples
       public const string APLOG_FUNCTIONKEY_SELECTED2 =
 @"  INFO [2024-03-08 08:58:12-281] [ScreenDecoratorLocal.OnFunctionKeySelected] The Yes button was pressed.
 ";
+      public const string APLOG_KEYPRESS =
+@"[2024-06-23 17:41:05-937][3][][ScreenDecoratorLocal][PinpadKeyPressed    ][NORMAL]PinpadKeyPressed, PostMessageevent WM_KEYDOWN WindowHandle, 0
+";
+
+      public const string APLOG_KEYPRESS_1 =
+@"  INFO [2024-09-05 03:15:16-644] [ScreenDecoratorLocal.PinpadKeyPressed] PinpadKeyPressed, PostMessageevent WM_KEYDOWN WindowHandle, 0
+";
 
       public const string APLOG_DEVICE_FITNESS =
 @"[2023-11-27 16:20:42-413][3][][FitnessData][GetDeviceFitness][NORMAL]Parameter pDvcStatus:DEVHWERROR

--- a/src/OverView/OverTable.cs
+++ b/src/OverView/OverTable.cs
@@ -501,6 +501,16 @@ namespace OverView
                         break;
                      }
 
+                  case APLogType.APLOG_KEYPRESS:
+                     {
+                        base.ProcessRow(logLine);
+                        if (apLogLine is APLine)
+                        {
+                           APLINE(apLogLine, "functionkey", "keypress");
+                        }
+                        break;
+                     }
+
 
                   /* cash dispenser */
 


### PR DESCRIPTION
Moved the Factory method into the APLine class and injected the APLine.Factory into APLogLineHandler. This decouples file reading from log line parsing. Updated the OverView view to include RFID message parsing. Added keypress to OverSummary.