### PR TITLE
Fix: Upated AP Log Parsing

### DIFF
--- a/src/APLine/APLine.cs
+++ b/src/APLine/APLine.cs
@@ -212,6 +212,9 @@ namespace LogLineHandler
 
 
       /* ERROR */
+
+      APLOG_ERROR, 
+
       Error
    }
 
@@ -567,6 +570,12 @@ namespace LogLineHandler
          /* Operator Menu */
          if (logLine.Contains("[OperatorWindow") && logLine.Contains("Parameter pMenuName:"))
             return new APLineField(logFileHandler, logLine, APLogType.APLOG_OPERATOR_MENU);
+
+         /* Error */
+         if (logLine.Contains(" ERROR ["))
+            return new APLineField(logFileHandler, logLine, APLogType.APLOG_ERROR);
+         
+
 
          return null;
       }

--- a/src/APLine/APLineField.cs
+++ b/src/APLine/APLineField.cs
@@ -288,6 +288,18 @@ namespace LogLineHandler
                   }
                   break;
                }
+
+            case APLogType.APLOG_ERROR:
+               {
+                  lookFor = "[";
+
+                  idx = logLine.LastIndexOf(lookFor);
+                  if (idx != -1)
+                  {
+                     field = logLine.Substring(idx + lookFor.Length).Trim().Trim(trimChars).Replace(']',',');
+                  }
+                  break;
+               }
          }
       }
    }

--- a/src/APLogLineTests/APLogHandler_IdentifyLines_Tests.cs
+++ b/src/APLogLineTests/APLogHandler_IdentifyLines_Tests.cs
@@ -452,5 +452,20 @@ namespace APLogLineTests
          Assert.IsTrue(apLine.Timestamp == "2024-09-05 03:15:16.644");
          Assert.IsTrue(apLine.HResult == "");
       }
+
+      [TestMethod]
+      public void APLOG_ERROR()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock(), ParseType.AP, APLine.Factory);
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_general.APLOG_ERROR);
+         Assert.IsTrue(logLine is APLineField);
+
+         APLineField apLine = (APLineField)logLine;
+         Assert.IsTrue(apLine.apType == APLogType.APLOG_ERROR);
+         Assert.IsTrue(apLine.Timestamp == "2024-08-29 17:44:54.672");
+         Assert.IsTrue(apLine.HResult == "");
+
+         Assert.IsTrue(apLine.field == "Encryption.EncryptString, Error found while encrypting:  no certificate was found");
+      }
    }
 }

--- a/src/APSamplesTests/samples_general.cs
+++ b/src/APSamplesTests/samples_general.cs
@@ -339,5 +339,11 @@ namespace APSamples
 @"[2024-08-15 09:33:55-766][3][][Account             ][.ctor               ][NORMAL]Account is Entered. Account = Supervisor
 ";
 
+      /* Error */
+      public const string APLOG_ERROR =
+@" ERROR [2024-08-29 17:44:54-672] [Encryption.EncryptString] Error found while encrypting:  no certificate was found
+";
+
+
    }
 }

--- a/src/OverView/OverTable.cs
+++ b/src/OverView/OverTable.cs
@@ -511,6 +511,18 @@ namespace OverView
                         break;
                      }
 
+                  /* Error */
+
+                  case APLogType.APLOG_ERROR:
+                     {
+                        base.ProcessRow(logLine);
+                        if (apLogLine is APLineField)
+                        {
+                           APLineField lineField = (APLineField)apLogLine;
+                           APLINE2(lineField, "error", "error", "comment", lineField.field);
+                        }
+                        break;
+                     }
 
                   /* cash dispenser */
 


### PR DESCRIPTION
Moved the Factory method into the APLine class and injected the APLine.Factory into APLogLineHandler. This decouples file reading from log line parsing. Updated the OverView view to include RFID message parsing. Added keypress to OverSummary.