### PR TITLE
fix: Update build.yml to fix pre-release naming issue. 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,9 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        
+    - name: Fetch all tags
+      run: git fetch --prune origin +refs/tags/*:refs/tags/*
     
     # Semantic Versioning
     - name: Semantic versioning  


### PR DESCRIPTION
Update build yml to fix a build numbering issue. Pre-release builds are not based on the latest release build.