### PR TITLE
Add ATM State Wall Clock visualization to OverView

### DIFF
--- a/docs/StateWallClock_Integration_README.md
+++ b/docs/StateWallClock_Integration_README.md
@@ -1,0 +1,110 @@
+# StateWallClock Integration Guide
+
+## Overview
+
+This feature adds ATM state duration analysis to OverView, generating pie charts that visualize machine availability across 12-hour periods (AM/PM).
+
+## Files
+
+1. **StateWallClockAnalyzer.cs** - New file
+   - Contains analysis logic
+   - Calculates state durations per day/period
+   - Handles Unknown state inference (start of day, end of day, PowerDown gaps)
+
+2. **OverView.cs** - Replacement
+   - Overrides `PreAnalyze()`, `Analyze()`, `PostAnalyze()`, and `WriteExcel()`
+   - Coordinates the analysis workflow
+
+3. **OverTable_Additions.cs** - Methods to add to OverTable.cs
+   - `GetSummaryTable()` - Returns the Summary DataTable for analysis
+   - `PopulateStateWallClockTable()` - Creates results table from analyzer
+   - `WriteStateWallClockExcel()` - Creates worksheet with pie charts
+   - `AddSummaryTable()` - Adds percentage summary table to worksheet
+
+## Integration Steps
+
+### 1. Add StateWallClockAnalyzer.cs
+Copy `StateWallClockAnalyzer.cs` to the OverView project folder.
+
+### 2. Replace OverView.cs
+Replace the existing `OverView.cs` with the new version.
+
+### 3. Update OverTable.cs
+Add the methods from `OverTable_Additions.cs` to the existing OverTable class:
+- Add `using System.Linq;` and Excel interop usings to the top of the file
+- Add the `#region StateWallClock Analysis Support` section to the class
+
+### 4. Verify COM References
+Ensure the project has references to both:
+- `Microsoft.Office.Interop.Excel`
+- `Microsoft Office 16.0 Object Library` (or your installed version)
+
+The Office Object Library is required because chart formatting uses Office core types.
+
+In Visual Studio: 
+1. Right-click project → Add → Reference
+2. Go to COM tab
+3. Check "Microsoft Office 16.0 Object Library"
+4. Click OK
+
+## Data Flow
+
+```
+PostProcess (existing)
+    │
+    └── Writes OverView.xml with Summary table
+            │
+            ▼
+PreAnalyze
+    │
+    ├── Loads OverView.xml
+    └── Creates StateWallClockAnalyzer
+            │
+            ▼
+Analyze
+    │
+    ├── Gets Summary DataTable
+    ├── Calculates state durations
+    └── Logs results
+            │
+            ▼
+PostAnalyze
+    │
+    └── Populates StateWallClock table
+            │
+            ▼
+WriteExcel
+    │
+    ├── Writes Summary worksheet (existing)
+    └── Writes StateWallClock worksheet with pie charts
+```
+
+## State Duration Rules
+
+| Scenario | State Assigned |
+|----------|---------------|
+| Midnight to first log entry | Unknown |
+| Last log entry to midnight | Unknown |
+| Last log entry before PowerUp to PowerUp | Unknown |
+| Mode value in log | That mode, until next mode change |
+
+## Chart Output
+
+- Two pie charts per day (AM: 00:00-12:00, PM: 12:00-24:00)
+- Color-coded by state:
+  - InService: Green
+  - OutOfService: Orange
+  - OffLine: Red
+  - PowerUp: Blue
+  - Supervisor: Purple
+  - Unknown: Gray
+- Summary table showing percentages for all periods
+
+## Testing
+
+Use the Python validation script to verify algorithm correctness:
+```bash
+python validate_algorithm.py
+```
+
+Expected output shows each period totaling exactly 12:00:00.

--- a/src/OverView/OverView.cs
+++ b/src/OverView/OverView.cs
@@ -1,12 +1,23 @@
-﻿using Contract;
+using Contract;
 using Impl;
 using System.ComponentModel.Composition;
+using System.Data;
 
 namespace OverView
 {
    [Export(typeof(IView))]
    public class OverView : BaseView, IView
    {
+      /// <summary>
+      /// The analyzer for calculating ATM state segments.
+      /// </summary>
+      private StateWallClockAnalyzer _wallClockAnalyzer;
+
+      /// <summary>
+      /// Reference to the OverTable for analysis phase.
+      /// </summary>
+      private OverTable _analyzeTable;
+
       /// <summary>
       /// Constructor
       /// </summary>
@@ -22,6 +33,116 @@ namespace OverView
          OverTable overTable = new OverTable(ctx, viewName);
          overTable.ReadXmlFile();
          return overTable;
+      }
+
+      /// <summary>
+      /// PreAnalyze: Load the Summary data and prepare for analysis.
+      /// </summary>
+      /// <param name="ctx">Context for the command.</param>
+      public override void PreAnalyze(IContext ctx)
+      {
+         ctx.LogWriteLine("------------------------------------------------");
+         ctx.LogWriteLine("PreAnalyze: " + viewName);
+
+         // Create table instance and load data from XML
+         _analyzeTable = new OverTable(ctx, viewName);
+         _analyzeTable.ReadXmlFile();
+
+         // Initialize the analyzer
+         _wallClockAnalyzer = new StateWallClockAnalyzer();
+
+         ctx.LogWriteLine("PreAnalyze: Data loaded for analysis");
+      }
+
+      /// <summary>
+      /// Analyze: Calculate ATM state segments for wall clock visualization.
+      /// </summary>
+      /// <param name="ctx">Context for the command.</param>
+      public override void Analyze(IContext ctx)
+      {
+         ctx.LogWriteLine("------------------------------------------------");
+         ctx.LogWriteLine("Analyze: " + viewName);
+
+         if (_analyzeTable == null || _wallClockAnalyzer == null)
+         {
+            ctx.LogWriteLine("Analyze: No data available for analysis");
+            return;
+         }
+
+         // Get the Summary table from the DataSet
+         DataTable summaryTable = _analyzeTable.GetSummaryTable();
+         if (summaryTable == null)
+         {
+            ctx.LogWriteLine("Analyze: Summary table not found");
+            return;
+         }
+
+         ctx.LogWriteLine($"Analyze: Processing {summaryTable.Rows.Count} rows from Summary table");
+
+         // Run the analysis
+         _wallClockAnalyzer.Analyze(summaryTable);
+
+         if (_wallClockAnalyzer.Results != null)
+         {
+            ctx.LogWriteLine($"Analyze: Generated {_wallClockAnalyzer.Results.Count} period results");
+
+            // Log the results
+            foreach (var period in _wallClockAnalyzer.Results)
+            {
+               ctx.LogWriteLine($"  {period.Date:yyyy-MM-dd} {period.Period}: {period.Segments.Count} segments");
+               foreach (var segment in period.Segments)
+               {
+                  ctx.LogWriteLine($"    {segment.StartTime:HH:mm:ss}-{segment.EndTime:HH:mm:ss} {segment.State} ({segment.Duration:hh\\:mm\\:ss})");
+               }
+            }
+         }
+      }
+
+      /// <summary>
+      /// PostAnalyze: Store results for later use in WriteExcel.
+      /// </summary>
+      /// <param name="ctx">Context for the command.</param>
+      public override void PostAnalyze(IContext ctx)
+      {
+         ctx.LogWriteLine("------------------------------------------------");
+         ctx.LogWriteLine("PostAnalyze: " + viewName);
+
+         if (_wallClockAnalyzer?.Results == null || _wallClockAnalyzer.Results.Count == 0)
+         {
+            ctx.LogWriteLine("PostAnalyze: No analysis results to save");
+            return;
+         }
+
+         // Populate the StateWallClock table in the OverTable
+         _analyzeTable.PopulateStateWallClockTable(_wallClockAnalyzer);
+
+         ctx.LogWriteLine("PostAnalyze: StateWallClock data prepared");
+      }
+
+      /// <summary>
+      /// WriteExcel: Write worksheets including StateWallClock with pie charts.
+      /// </summary>
+      /// <param name="ctx">Context for the command.</param>
+      public override void WriteExcel(IContext ctx)
+      {
+         ctx.ConsoleWriteLogLine("------------------------------------------------");
+         ctx.ConsoleWriteLogLine("WriteExcel: " + viewName);
+
+         // Create a Table Instance and load up the xml file
+         OverTable overTable = new OverTable(ctx, viewName);
+         overTable.ReadXmlFile();
+
+         // Write the standard Summary worksheet
+         overTable.WriteExcelFile();
+
+         // If we have analysis results, write the StateWallClock worksheet with charts
+         if (_wallClockAnalyzer?.Results != null && _wallClockAnalyzer.Results.Count > 0)
+         {
+            ctx.ConsoleWriteLogLine("WriteExcel: Writing StateWallClock worksheet with wall clock charts");
+            overTable.WriteStateWallClockExcel(_wallClockAnalyzer.Results);
+         }
+
+         ctx.ConsoleWriteLogLine("End WriteExcel: " + viewName);
       }
    }
 }

--- a/src/OverView/OverView.csproj
+++ b/src/OverView/OverView.csproj
@@ -31,6 +31,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Office.Interop.Excel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Office.Interop.Excel.15.0.4795.1001\lib\net20\Microsoft.Office.Interop.Excel.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
@@ -50,6 +54,7 @@
       <DependentUpon>OverView.xsd</DependentUpon>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StateWallClockAnalyzer.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\APLine\APLogLine.csproj">
@@ -85,12 +90,15 @@
     <None Include="OverView.xss">
       <DependentUpon>OverView.xsd</DependentUpon>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="OverView.xml" />
   </ItemGroup>
   <ItemGroup>
     <WCFMetadata Include="Connected Services\" />
+  </ItemGroup>
+  <ItemGroup>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/src/OverView/StateWallClockAnalyzer.cs
+++ b/src/OverView/StateWallClockAnalyzer.cs
@@ -1,0 +1,310 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+
+namespace OverView
+{
+   /// <summary>
+   /// Represents a single time segment with a specific state.
+   /// Used to create chronological pie slices for wall clock visualization.
+   /// </summary>
+   public class StateSegment
+   {
+      public DateTime StartTime { get; set; }
+      public DateTime EndTime { get; set; }
+      public string State { get; set; }
+      public string Label { get; set; }  // Unique label for pie chart (e.g., "InService_1")
+
+      public TimeSpan Duration => EndTime - StartTime;
+      public double DurationSeconds => Duration.TotalSeconds;
+   }
+
+   /// <summary>
+   /// Represents state segments for a 12-hour period (AM or PM) of a single day.
+   /// Segments are in chronological order for wall clock visualization.
+   /// </summary>
+   public class PeriodStateSegments
+   {
+      public DateTime Date { get; set; }
+      public string Period { get; set; } // "AM" or "PM"
+      public List<StateSegment> Segments { get; set; }
+
+      public PeriodStateSegments(DateTime date, string period)
+      {
+         Date = date;
+         Period = period;
+         Segments = new List<StateSegment>();
+      }
+
+      /// <summary>
+      /// Add a segment and assign a unique label.
+      /// </summary>
+      public void AddSegment(DateTime start, DateTime end, string state)
+      {
+         if (start >= end)
+            return;
+
+         // Count existing segments with same state to create unique label
+         int count = Segments.Count(s => s.State == state) + 1;
+
+         Segments.Add(new StateSegment
+         {
+            StartTime = start,
+            EndTime = end,
+            State = state,
+            Label = $"{state}_{count}"
+         });
+      }
+
+      public TimeSpan TotalDuration => Segments.Aggregate(TimeSpan.Zero, (sum, s) => sum + s.Duration);
+   }
+
+   /// <summary>
+   /// Analyzes OverSummary data to calculate ATM state segments for wall clock visualization.
+   /// Produces chronologically ordered segments that map directly to pie chart slices.
+   /// </summary>
+   public class StateWallClockAnalyzer
+   {
+      private const string STATE_UNKNOWN = "Unknown";
+      private const string STATE_POWERUP = "PowerUp";
+
+      private List<PeriodStateSegments> _results;
+
+      /// <summary>
+      /// Analysis results - list of period segments for each day/period combination.
+      /// </summary>
+      public List<PeriodStateSegments> Results => _results;
+
+      /// <summary>
+      /// Analyze the Summary DataTable to calculate state segments per day and period.
+      /// </summary>
+      /// <param name="summaryTable">The Summary DataTable from OverTable</param>
+      public void Analyze(DataTable summaryTable)
+      {
+         _results = new List<PeriodStateSegments>();
+
+         if (summaryTable == null || summaryTable.Rows.Count == 0)
+         {
+            return;
+         }
+
+         // Extract all log entries with time, and those with mode values
+         var logEntries = ExtractLogEntries(summaryTable);
+         if (logEntries.Count == 0)
+         {
+            return;
+         }
+
+         // Find the full date range
+         DateTime firstDate = logEntries.Min(e => e.Time.Date);
+         DateTime lastDate = logEntries.Max(e => e.Time.Date);
+
+         // Group entries by day for lookup
+         var entriesByDay = logEntries.GroupBy(e => e.Time.Date)
+                                       .ToDictionary(g => g.Key, g => g.OrderBy(e => e.Time).ToList());
+
+         // Process EVERY day in the range, including days with no entries
+         for (DateTime date = firstDate; date <= lastDate; date = date.AddDays(1))
+         {
+            var amPeriod = new PeriodStateSegments(date, "AM");
+            var pmPeriod = new PeriodStateSegments(date, "PM");
+
+            if (entriesByDay.TryGetValue(date, out var dayEntries))
+            {
+               // Day has log entries - process normally
+               CalculateSegmentsForDay(dayEntries, date, amPeriod, pmPeriod);
+            }
+            else
+            {
+               // Day has NO log entries - entire day is Unknown
+               DateTime dayStart = date;
+               DateTime noon = date.AddHours(12);
+               DateTime dayEnd = date.AddDays(1);
+
+               amPeriod.AddSegment(dayStart, noon, STATE_UNKNOWN);
+               pmPeriod.AddSegment(noon, dayEnd, STATE_UNKNOWN);
+            }
+
+            _results.Add(amPeriod);
+            _results.Add(pmPeriod);
+         }
+      }
+
+      /// <summary>
+      /// Populate a DataTable with the analysis results (for XML output).
+      /// </summary>
+      /// <param name="resultsTable">Target DataTable</param>
+      public void PopulateResultsTable(DataTable resultsTable)
+      {
+         if (_results == null || resultsTable == null)
+            return;
+
+         foreach (var period in _results)
+         {
+            foreach (var segment in period.Segments)
+            {
+               DataRow row = resultsTable.NewRow();
+               row["Date"] = period.Date.ToString("yyyy-MM-dd");
+               row["Period"] = period.Period;
+               row["State"] = segment.State;
+               row["Label"] = segment.Label;
+               row["StartTime"] = segment.StartTime.ToString("HH:mm:ss");
+               row["EndTime"] = segment.EndTime.ToString("HH:mm:ss");
+               row["DurationSeconds"] = segment.DurationSeconds;
+               row["DurationFormatted"] = FormatDuration(segment.Duration);
+               resultsTable.Rows.Add(row);
+            }
+         }
+
+         resultsTable.AcceptChanges();
+      }
+
+      #region Private Methods
+
+      private List<LogEntry> ExtractLogEntries(DataTable summaryTable)
+      {
+         var entries = new List<LogEntry>();
+
+         if (!summaryTable.Columns.Contains("time"))
+         {
+            return entries;
+         }
+
+         bool hasModeColumn = summaryTable.Columns.Contains("mode");
+
+         foreach (DataRow row in summaryTable.Rows)
+         {
+            if (row["time"] == DBNull.Value)
+               continue;
+
+            DateTime time;
+            if (row["time"] is DateTime dt)
+            {
+               time = dt;
+            }
+            else if (!DateTime.TryParse(row["time"].ToString(), out time))
+            {
+               continue;
+            }
+
+            string mode = null;
+            if (hasModeColumn && row["mode"] != DBNull.Value)
+            {
+               string modeValue = row["mode"].ToString().Trim();
+               if (!string.IsNullOrEmpty(modeValue))
+                  mode = modeValue;
+            }
+
+            entries.Add(new LogEntry { Time = time, Mode = mode });
+         }
+
+         return entries;
+      }
+
+      private void CalculateSegmentsForDay(List<LogEntry> dayEntries, DateTime date,
+          PeriodStateSegments amPeriod, PeriodStateSegments pmPeriod)
+      {
+         DateTime dayStart = date;
+         DateTime noon = date.AddHours(12);
+         DateTime dayEnd = date.AddDays(1);
+
+         DateTime currentTime = dayStart;
+         string currentState = STATE_UNKNOWN;
+         DateTime? lastLogEntryTime = null;
+
+         foreach (var entry in dayEntries)
+         {
+            // Check if this is a PowerUp - if so, mark time since last log entry as Unknown
+            if (entry.Mode == STATE_POWERUP && lastLogEntryTime.HasValue)
+            {
+               // Record segment from currentTime to lastLogEntryTime in currentState
+               if (lastLogEntryTime.Value > currentTime)
+               {
+                  RecordSegment(currentTime, lastLogEntryTime.Value, currentState, noon, amPeriod, pmPeriod);
+                  currentTime = lastLogEntryTime.Value;
+               }
+
+               // Record segment from lastLogEntryTime to PowerUp as Unknown
+               RecordSegment(currentTime, entry.Time, STATE_UNKNOWN, noon, amPeriod, pmPeriod);
+               currentTime = entry.Time;
+               currentState = STATE_POWERUP;
+            }
+            else if (entry.Mode != null)
+            {
+               // Regular mode change - record segment in previous state
+               if (entry.Time > currentTime)
+               {
+                  RecordSegment(currentTime, entry.Time, currentState, noon, amPeriod, pmPeriod);
+                  currentTime = entry.Time;
+               }
+               currentState = entry.Mode;
+            }
+
+            // Track last log entry time (regardless of whether it has a mode)
+            lastLogEntryTime = entry.Time;
+         }
+
+         // Handle end of day - from last log entry to midnight is Unknown
+         if (lastLogEntryTime.HasValue && lastLogEntryTime.Value < dayEnd)
+         {
+            // First, record any remaining time in current state up to last log entry
+            if (lastLogEntryTime.Value > currentTime)
+            {
+               RecordSegment(currentTime, lastLogEntryTime.Value, currentState, noon, amPeriod, pmPeriod);
+               currentTime = lastLogEntryTime.Value;
+            }
+
+            // Then record Unknown from last log entry to end of day
+            RecordSegment(currentTime, dayEnd, STATE_UNKNOWN, noon, amPeriod, pmPeriod);
+         }
+         else if (currentTime < dayEnd)
+         {
+            // No log entries at all
+            RecordSegment(currentTime, dayEnd, STATE_UNKNOWN, noon, amPeriod, pmPeriod);
+         }
+      }
+
+      private void RecordSegment(DateTime start, DateTime end, string state,
+          DateTime noon, PeriodStateSegments amPeriod, PeriodStateSegments pmPeriod)
+      {
+         if (start >= end)
+            return;
+
+         // Split at noon if necessary
+         if (start < noon && end <= noon)
+         {
+            // Entirely in AM
+            amPeriod.AddSegment(start, end, state);
+         }
+         else if (start >= noon && end > noon)
+         {
+            // Entirely in PM
+            pmPeriod.AddSegment(start, end, state);
+         }
+         else if (start < noon && end > noon)
+         {
+            // Spans noon - split it
+            amPeriod.AddSegment(start, noon, state);
+            pmPeriod.AddSegment(noon, end, state);
+         }
+      }
+
+      private string FormatDuration(TimeSpan duration)
+      {
+         return $"{(int)duration.TotalHours:D2}:{duration.Minutes:D2}:{duration.Seconds:D2}";
+      }
+
+      #endregion
+
+      #region Helper Classes
+
+      private class LogEntry
+      {
+         public DateTime Time { get; set; }
+         public string Mode { get; set; }
+      }
+
+      #endregion
+   }
+}


### PR DESCRIPTION
Adds a new StateWallClock worksheet with pie chart visualizations showing ATM operational state over time. Charts use a wall clock metaphor where 12 o'clock represents the start of each period and slices proceed clockwise in chronological order.

Features:
- AM (00:00-12:00) and PM (12:00-24:00) charts for each day
- Color-coded states: InService (green), OutOfService (orange), OffLine (red), PowerUp (blue), Supervisor (purple), Unknown (gray)
- Missing days in date range shown as 100% Unknown
- Clean visualization with no legends or labels for at-a-glance analysis
- Data table with segment details and color key

New files:
- StateWallClockAnalyzer.cs

Modified files:
- OverView.cs (added Analyze phase overrides)
- OverTable.cs (added chart generation methods)