### PR TITLE
feat: WinCE TraceView: Fix timestamp parsing and add column structure…

### DIFF
--- a/src/WinCETrcView/WinCETraceTable.cs
+++ b/src/WinCETrcView/WinCETraceTable.cs
@@ -7,8 +7,8 @@ using LogLineHandler;
 namespace WinCETraceView
 {
    /// <summary>
-   /// Table for WinCE trace log data.
-   /// Stores parsed trace entries for Excel output.
+   /// Table class for WinCE trace log data.
+   /// Stores parsed trace entries for Excel output, matching TraceViewer column layout.
    /// </summary>
    class WinCETraceTable : BaseTable
    {
@@ -42,27 +42,76 @@ namespace WinCETraceView
       }
 
       /// <summary>
-      /// Add a trace line to the Summary table
+      /// Add a trace line to the Summary table.
+      /// Columns match TraceViewer layout: Date/Time, UNIT, Func, Error, Data, Module Name, Class Name, Func. Name
       /// </summary>
       /// <param name="traceLine">Parsed trace line</param>
       protected void AddTraceRow(WinCETraceLine traceLine)
       {
          try
          {
-            DataRow dataRow = dTableSet.Tables["Summary"].Rows.Add();
+            DataRow dataRow = dTableSet.Tables["Summary"].NewRow();
 
             dataRow["file"] = traceLine.LogFile;
-            dataRow["time"] = traceLine.Timestamp;
-            dataRow["type"] = traceLine.LogType.ToString() + " - " + traceLine.traceType.ToString();
-            dataRow["code"] = traceLine.Code;
-            dataRow["message"] = traceLine.Message;
+            dataRow["time"] = traceLine.Timestamp;                    // Now includes seconds: "2025-04-09 09:26:32.000"
+            dataRow["type"] = traceLine.LogType.ToString();           // 'o', 'O', 'f', 'F', 's', 't'
+            dataRow["unit"] = traceLine.Unit;                         // First 2 chars of code: "1E", "54", "1A", etc.
+            dataRow["func"] = traceLine.Func;                         // Chars 2-3 of code: "12", "30", "01", etc.
+            dataRow["error"] = traceLine.Error;                       // Chars 4-10 of code: "0000000", "9999999", etc.
+            dataRow["data"] = traceLine.Message;                      // The trace message text
 
+            // Lookup columns from Messages table using Unit+Func as the key
+            string lookupKey = traceLine.Unit + traceLine.Func;       // e.g., "1E12", "1A01", "5430"
+            dataRow["modulename"] = LookupMessage("modulename", lookupKey);
+            dataRow["classname"] = LookupMessage("classname", lookupKey);
+            dataRow["funcname"] = LookupMessage("funcname", lookupKey);
+
+            dTableSet.Tables["Summary"].Rows.Add(dataRow);
             dTableSet.Tables["Summary"].AcceptChanges();
          }
          catch (Exception e)
          {
             ctx.ConsoleWriteLogLine("WinCETraceTable.AddTraceRow Exception: " + e.Message);
          }
+      }
+
+      /// <summary>
+      /// Generic lookup in Messages table by type and code.
+      /// The Messages table has columns: type, code, description
+      /// - type: "modulename", "classname", or "funcname"
+      /// - code: Unit+Func concatenated (e.g., "1E12", "1A01")
+      /// - description: The human-readable value
+      /// </summary>
+      /// <param name="messageType">Type of lookup: "modulename", "classname", or "funcname"</param>
+      /// <param name="code">The Unit+Func code to look up (e.g., "1E12")</param>
+      /// <returns>The description from the Messages table, or empty string if not found</returns>
+      private string LookupMessage(string messageType, string code)
+      {
+         if (string.IsNullOrEmpty(code))
+            return string.Empty;
+
+         try
+         {
+            if (dTableSet.Tables.Contains("Messages"))
+            {
+               DataTable messagesTable = dTableSet.Tables["Messages"];
+               foreach (DataRow row in messagesTable.Rows)
+               {
+                  string rowType = row["type"]?.ToString();
+                  string rowCode = row["code"]?.ToString();
+                  if (rowType == messageType && rowCode == code)
+                  {
+                     return row["description"]?.ToString() ?? string.Empty;
+                  }
+               }
+            }
+         }
+         catch
+         {
+            // Return empty on lookup failure
+         }
+
+         return string.Empty;
       }
    }
 }

--- a/src/WinCETrcView/WinCETraceView.xml
+++ b/src/WinCETrcView/WinCETraceView.xml
@@ -1,64 +1,102 @@
 <?xml version="1.0" standalone="yes"?>
-<WinCETrace>
-  <!-- Summary table structure - one row per trace entry -->
+<WinCETraceView>
+  <!-- Summary table - one row per trace entry -->
   <Summary>
     <file></file>
     <time></time>
     <type></type>
-    <code></code>
-    <message></message>
+    <unit></unit>
+    <func></func>
+    <error></error>
+    <data></data>
+    <modulename></modulename>
+    <classname></classname>
+    <funcname></funcname>
   </Summary>
 
-  <!-- Log Type Messages -->
-  <Messages>
-    <type>LogType</type>
-    <code>o</code>
-    <brief>operation</brief>
-    <description>Normal operation trace</description>
-  </Messages>
+  <!-- Messages table for Unit+Func code lookups -->
+  <!-- type: "modulename", "classname", or "funcname" -->
+  <!-- code: Unit+Func concatenated (e.g., "1E12" = Unit "1E" + Func "12") -->
+  <!-- description: Human-readable value -->
 
-  <Messages>
-    <type>LogType</type>
-    <code>O</code>
-    <brief>Operation</brief>
-    <description>Operation trace (uppercase)</description>
-  </Messages>
+  <!-- Based on TraceViewer screenshot observations: -->
+  
+  <!-- Unit 1E (DevCtrl.dll / DevApl.cpp) -->
+  <Messages><type>modulename</type><code>1E12</code><description>DevCtrl.dll</description></Messages>
+  <Messages><type>classname</type><code>1E12</code><description>DevApl.cpp</description></Messages>
+  <Messages><type>funcname</type><code>1E12</code><description>fnAPL_SetProcCount</description></Messages>
 
-  <Messages>
-    <type>LogType</type>
-    <code>f</code>
-    <brief>fatal</brief>
-    <description>Fatal error trace</description>
-  </Messages>
+  <Messages><type>modulename</type><code>1E21</code><description>DevCtrl.dll</description></Messages>
+  <Messages><type>classname</type><code>1E21</code><description>DevApl.cpp</description></Messages>
+  <Messages><type>funcname</type><code>1E21</code><description>fnAPL_StackError</description></Messages>
 
-  <Messages>
-    <type>LogType</type>
-    <code>s</code>
-    <brief>system</brief>
-    <description>System trace</description>
-  </Messages>
+  <!-- Unit 1A (WinAtm.exe / CMainFrame) -->
+  <Messages><type>modulename</type><code>1A01</code><description>WinAtm.exe</description></Messages>
+  <Messages><type>classname</type><code>1A01</code><description>CMainFrame</description></Messages>
+  <Messages><type>funcname</type><code>1A01</code><description>AtmModeCtrl</description></Messages>
 
-  <!-- Layer Code Messages (known codes from legacy viewer) -->
-  <!-- Add more codes as they are discovered from log analysis -->
-  <Messages>
-    <type>LayerCode</type>
-    <code>1A010000000</code>
-    <brief>ATM_ERROR</brief>
-    <description>ATM Error layer</description>
-  </Messages>
+  <Messages><type>modulename</type><code>1A11</code><description>WinAtm.exe</description></Messages>
+  <Messages><type>classname</type><code>1A11</code><description>CMainFrame</description></Messages>
+  <Messages><type>funcname</type><code>1A11</code><description>Check_NVRamSetupValue</description></Messages>
 
-  <Messages>
-    <type>LayerCode</type>
-    <code>551A0000000</code>
-    <brief>SYSTEM</brief>
-    <description>System layer</description>
-  </Messages>
+  <!-- Unit 55 (NH_SIU.exe / CNH_SIUDev) -->
+  <Messages><type>modulename</type><code>551A</code><description>NH_SIU.exe</description></Messages>
+  <Messages><type>classname</type><code>551A</code><description>CNH_SIUDev</description></Messages>
+  <Messages><type>funcname</type><code>551A</code><description>SetGuidLight</description></Messages>
 
-  <Messages>
-    <type>LayerCode</type>
-    <code>1V020000000</code>
-    <brief>DEVICE</brief>
-    <description>Device layer</description>
-  </Messages>
+  <!-- Unit 1K (NetCtrl.dll / CVISAllCtrl) -->
+  <Messages><type>modulename</type><code>1K01</code><description>NetCtrl.dll</description></Messages>
+  <Messages><type>classname</type><code>1K01</code><description>CVISAllCtrl</description></Messages>
+  <Messages><type>funcname</type><code>1K01</code><description>FLOWSTART</description></Messages>
 
-</WinCETrace>
+  <!-- Unit 1V (LibUpdate.dll / CUpdateRepoService) -->
+  <Messages><type>modulename</type><code>1V00</code><description>LibUpdate.dll</description></Messages>
+  <Messages><type>classname</type><code>1V00</code><description>CUpdateRepoConfiguratio...</description></Messages>
+  <Messages><type>funcname</type><code>1V00</code><description>GetConfiguration</description></Messages>
+
+  <Messages><type>modulename</type><code>1V02</code><description>LibUpdate.dll</description></Messages>
+  <Messages><type>classname</type><code>1V02</code><description>CUpdateRepoService</description></Messages>
+  <Messages><type>funcname</type><code>1V02</code><description>GetComponentContents</description></Messages>
+
+  <Messages><type>modulename</type><code>1V04</code><description>LibUpdate.dll</description></Messages>
+  <Messages><type>classname</type><code>1V04</code><description>CUpdateRepoService</description></Messages>
+  <Messages><type>funcname</type><code>1V04</code><description>GetLatestPackageManifest</description></Messages>
+
+  <Messages><type>modulename</type><code>1V07</code><description>LibUpdate.dll</description></Messages>
+  <Messages><type>classname</type><code>1V07</code><description>CUpdateRepoService</description></Messages>
+  <Messages><type>funcname</type><code>1V07</code><description>ValidateManifest</description></Messages>
+
+  <!-- Unit 10 (various) -->
+  <Messages><type>modulename</type><code>1001</code><description></description></Messages>
+  <Messages><type>classname</type><code>1001</code><description></description></Messages>
+  <Messages><type>funcname</type><code>1001</code><description>ClerkProc</description></Messages>
+
+  <!-- Unit 54 (sensor status - typically no module/class/func) -->
+  <Messages><type>modulename</type><code>5430</code><description></description></Messages>
+  <Messages><type>classname</type><code>5430</code><description></description></Messages>
+  <Messages><type>funcname</type><code>5430</code><description></description></Messages>
+
+  <!-- Unit 51 -->
+  <Messages><type>modulename</type><code>513B</code><description></description></Messages>
+  <Messages><type>classname</type><code>513B</code><description></description></Messages>
+  <Messages><type>funcname</type><code>513B</code><description></description></Messages>
+
+  <Messages><type>modulename</type><code>5140</code><description></description></Messages>
+  <Messages><type>classname</type><code>5140</code><description></description></Messages>
+  <Messages><type>funcname</type><code>5140</code><description></description></Messages>
+
+  <!-- 
+  TODO: Add more Unit+Func combinations as discovered from log files.
+  The TraceViewer application has a built-in lookup table for these codes.
+  This XML can be extended to match that table.
+  
+  Pattern observed:
+  - Unit "1E" = DevCtrl.dll / DevApl.cpp
+  - Unit "1A" = WinAtm.exe / CMainFrame  
+  - Unit "1K" = NetCtrl.dll / CVISAllCtrl
+  - Unit "1V" = LibUpdate.dll / CUpdateRepoService
+  - Unit "55" = NH_SIU.exe / CNH_SIUDev
+  - Unit "54", "51" = Hardware/sensor status (usually no module info)
+  -->
+
+</WinCETraceView>

--- a/src/WinCETrcView/WinCETraceView.xsd
+++ b/src/WinCETrcView/WinCETraceView.xsd
@@ -1,19 +1,38 @@
 <?xml version="1.0" standalone="yes"?>
-<xs:schema id="WinCETrace" xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-  <xs:element name="WinCETrace" msdata:IsDataSet="true" msdata:UseCurrentLocale="true">
+<xs:schema id="WinCETraceView" xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+  <xs:element name="WinCETraceView" msdata:IsDataSet="true" msdata:UseCurrentLocale="true">
     <xs:complexType>
       <xs:choice minOccurs="0" maxOccurs="unbounded">
+        
+        <!-- Summary table - one row per trace entry matching TraceViewer columns -->
         <xs:element name="Summary">
           <xs:complexType>
             <xs:sequence>
               <xs:element name="file" type="xs:string" minOccurs="0" />
               <xs:element name="time" type="xs:string" minOccurs="0" />
               <xs:element name="type" type="xs:string" minOccurs="0" />
-              <xs:element name="code" type="xs:string" minOccurs="0" />
-              <xs:element name="message" type="xs:string" minOccurs="0" />
+              <xs:element name="unit" type="xs:string" minOccurs="0" />
+              <xs:element name="func" type="xs:string" minOccurs="0" />
+              <xs:element name="error" type="xs:string" minOccurs="0" />
+              <xs:element name="data" type="xs:string" minOccurs="0" />
+              <xs:element name="modulename" type="xs:string" minOccurs="0" />
+              <xs:element name="classname" type="xs:string" minOccurs="0" />
+              <xs:element name="funcname" type="xs:string" minOccurs="0" />
             </xs:sequence>
           </xs:complexType>
         </xs:element>
+
+        <!-- Messages table for Unit+Func code lookups -->
+        <xs:element name="Messages">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="type" type="xs:string" minOccurs="0" />
+              <xs:element name="code" type="xs:string" minOccurs="0" />
+              <xs:element name="description" type="xs:string" minOccurs="0" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
       </xs:choice>
     </xs:complexType>
   </xs:element>


### PR DESCRIPTION
… matching TraceViewer

Fixed binary log parsing to correctly interpret timestamp bytes as Hour/Minute/Second (previously misinterpreted as Day/Hour/Minute). Added separate Unit, Func, and Error columns matching the legacy TraceViewer application layout.

Changes:
- WinCETraceLine.cs: Corrected timestamp byte order (HH:MM:SS not DD:HH:MM)
- WinCETraceLine.cs: Extract full date (YYYY-MM-DD) from filename instead of YYYY-MM
- WinCETraceLine.cs: Added Unit, Func, Error properties parsed from 11-char code
- WinCETraceTable.cs: Map new properties to columns, added lookup method
- WinCETraceView.xsd/xml: Added columns for unit, func, error, modulename, classname, funcname

Known limitation:
Module Name, Class Name, and Func Name columns require a lookup table mapping Unit+Func codes to human-readable values. Awaiting mapping data from WinCE Development team. Columns will be empty until lookup table is populated.