### PR TITLE
feat: Add DEVICE_ERROR parsing for packed binary device errors in nwlog files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,8 +58,8 @@ jobs:
     - name: Setup VSTest Path
       uses: darenm/Setup-VSTest@v1.2
                  
-    # Test
-    - name: Test
+    # Test C:\Program Files\Microsoft Visual Studio\18\Community\Common7\IDE\Extensions\TestPlatform
+    - name: Test 
       run: msbuild src\\splogparser.sln /t:RunUnitTests /p:Configuration="Release" /p:Platform="Any CPU"
 
     # Build hylogparser (.NET 10 WPF, single-file publish into dist\)

--- a/src/CDMView/CDMTable.cs
+++ b/src/CDMView/CDMTable.cs
@@ -97,6 +97,13 @@ namespace CDMView
                         WFS_SRVE_CDM_ITEMSTAKEN(spLogLine);
                         break;
                      }
+                  case LogLineHandler.XFSType.DEVICE_ERROR:
+                     {
+                        base.ProcessRow(spLogLine);
+                        DEVICE_ERROR(spLogLine);
+                        break;
+                     }
+
                   default:
                      break;
 
@@ -755,6 +762,27 @@ namespace CDMView
          catch (Exception e)
          {
             ctx.ConsoleWriteLogLine("WFS_SRVE_CDM_ITEMSTAKEN Exception : " + e.Message);
+         }
+      }
+      protected void DEVICE_ERROR(SPLine spLogLine)
+      {
+         try
+         {
+            if (spLogLine is SPDEVICEERROR deviceError)
+            {
+               DataRow dataRow = dTableSet.Tables["Dispense"].Rows.Add();
+
+               dataRow["file"] = spLogLine.LogFile;
+               dataRow["time"] = spLogLine.Timestamp;
+               dataRow["error"] = spLogLine.HResult;
+               dataRow["position"] = deviceError.ClassName + "::" + deviceError.Operation;
+
+               dTableSet.Tables["Dispense"].AcceptChanges();
+            }
+         }
+         catch (Exception e)
+         {
+            ctx.ConsoleWriteLogLine("CDMTable.DEVICE_ERROR Exception : " + e.Message);
          }
       }
    }

--- a/src/CIMView/CIMTable.cs
+++ b/src/CIMView/CIMTable.cs
@@ -150,6 +150,13 @@ namespace CIMView
                         CIM_UPDATE_POSITION(spLogLine, "detected", "WFS_SRVE_IPM_MEDIADETECTED");
                         break;
                      }
+                  case LogLineHandler.XFSType.DEVICE_ERROR:
+                     {
+                        base.ProcessRow(spLogLine);
+                        DEVICE_ERROR(spLogLine);
+                        break;
+                     }
+
                   default:
                      break;
                }
@@ -1431,6 +1438,30 @@ namespace CIMView
          catch (Exception e)
          {
             ctx.ConsoleWriteLogLine(xfsString + " Exception : " + e.Message);
+         }
+      }
+      protected void DEVICE_ERROR(SPLine spLogLine)
+      {
+         try
+         {
+            if (spLogLine is SPDEVICEERROR deviceError)
+            {
+               // Deposit table has errcode from PR #217
+               DataRow dataRow = dTableSet.Tables["Deposit"].Rows.Add();
+
+               dataRow["file"] = spLogLine.LogFile;
+               dataRow["time"] = spLogLine.Timestamp;
+               dataRow["error"] = spLogLine.HResult;
+               dataRow["errcode"] = deviceError.ErrorCode;
+               dataRow["position"] = deviceError.ClassName + "::" + deviceError.Operation;
+               dataRow["comment"] = deviceError.ErrorMessage;
+
+               dTableSet.Tables["Deposit"].AcceptChanges();
+            }
+         }
+         catch (Exception e)
+         {
+            ctx.ConsoleWriteLogLine("CIMTable.DEVICE_ERROR Exception : " + e.Message);
          }
       }
    }

--- a/src/CIMView/CIMView.csproj
+++ b/src/CIMView/CIMView.csproj
@@ -77,5 +77,13 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="CIMView.xsc">
+      <DependentUpon>CIMView.xsd</DependentUpon>
+    </None>
+    <None Include="CIMView.xss">
+      <DependentUpon>CIMView.xsd</DependentUpon>
+    </None>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/DEVView/DEVTable.cs
+++ b/src/DEVView/DEVTable.cs
@@ -133,6 +133,12 @@ namespace DeviceView
                         WFSSYSEVENT(spLogLine);
                         break;
                      }
+                  case LogLineHandler.XFSType.DEVICE_ERROR:
+                     {
+                        base.ProcessRow(spLogLine);
+                        DEVICE_ERROR(spLogLine);
+                        break;
+                     }
                   default:
                      break;
                }
@@ -307,5 +313,36 @@ namespace DeviceView
             ctx.ConsoleWriteLogLine("WFSSYSEVENT Exception : " + e.Message);
          }
       }
+      protected void DEVICE_ERROR(SPLine spLogLine)
+      {
+         try
+         {
+            if (spLogLine is SPDEVICEERROR deviceError)
+            {
+               DataRow dataRow = dTableSet.Tables["Status"].Rows.Add();
+
+               dataRow["file"] = spLogLine.LogFile;
+               dataRow["time"] = spLogLine.Timestamp;
+               dataRow["error"] = spLogLine.HResult;
+
+               // Put the class name in the matching device column
+               string deviceCol = string.Empty;
+               if (deviceError.ClassName.Contains("CIM") || deviceError.ClassName.Contains("BRM"))
+                  deviceCol = "CIM";
+               else if (deviceError.ClassName.Contains("CDM"))
+                  deviceCol = "CDM";
+
+               if (!string.IsNullOrEmpty(deviceCol))
+                  dataRow[deviceCol] = deviceError.Operation + " error=[" + deviceError.ErrorCode + "]";
+
+               dTableSet.Tables["Status"].AcceptChanges();
+            }
+         }
+         catch (Exception e)
+         {
+            ctx.ConsoleWriteLogLine("DEVTable.DEVICE_ERROR Exception : " + e.Message);
+         }
+      }
+
    }
 }

--- a/src/SPLogLine/SPDEVICEERROR.cs
+++ b/src/SPLogLine/SPDEVICEERROR.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using Contract;
+
+namespace LogLineHandler
+{
+   public class SPDEVICEERROR : SPLine
+   {
+      public string ClassName { get; set; }     // CCCIMDev, CBRM20
+      public string Operation { get; set; }     // _Retract, _DepositCheck, Dispense, _Initialize
+      public string ErrorCode { get; set; }     // 9889, 4C0D, 70D1A2
+      public string ErrorMessage { get; set; }  // "Fail to _Retract with error=[9889]"
+
+      // Packed binary timestamp: date, 4-digit length prefix, then time
+      private static readonly Regex timestampRegex = new Regex(
+         @"(\d{4}/\d{2}/\d{2})\d{4}(\d{2}:\d{2} \d{2}\.\d{3})",
+         RegexOptions.Compiled);
+
+      // "Fail to X with ... error=[hex]" or "Failed to X with ... error=[hex]"
+      private static readonly Regex errorRegex = new Regex(
+         @"Fail(?:ed)? to (\w+) with.*?error=\[([A-Fa-f0-9]+)\]",
+         RegexOptions.Compiled);
+
+      // Class::Operation before the error message
+      private static readonly Regex classOpRegex = new Regex(
+         @"(\w+)::(_?\w+)",
+         RegexOptions.Compiled);
+
+      public SPDEVICEERROR(ILogFileHandler parent, string logLine, XFSType xfsType = XFSType.DEVICE_ERROR)
+         : base(parent, logLine, xfsType)
+      {
+      }
+
+      protected override void Initialize()
+      {
+         Timestamp = tsTimestamp();
+         IsValidTimestamp = bCheckValidTimestamp(Timestamp);
+         HResult = hResult();
+
+         // Parse class::operation
+         Match classMatch = classOpRegex.Match(logLine);
+         if (classMatch.Success)
+         {
+            ClassName = classMatch.Groups[1].Value;
+            Operation = classMatch.Groups[2].Value;
+         }
+
+         // Parse error message and code - Operation here wins over classOpRegex
+         // because it captures the actual failed action
+         Match errorMatch = errorRegex.Match(logLine);
+         if (errorMatch.Success)
+         {
+            Operation = errorMatch.Groups[1].Value;
+            ErrorCode = errorMatch.Groups[2].Value;
+            ErrorMessage = errorMatch.Value;
+         }
+
+         Console.WriteLine($"SPDEVICEERROR: {Timestamp} {ClassName}::{Operation} error=[{ErrorCode}]");
+      }
+
+      protected override string tsTimestamp()
+      {
+         // Extract timestamp from packed binary format
+         // e.g. "00102026/03/31001210:36 21.192" -> "2026-03-31 10:36:21.192"
+         Match m = timestampRegex.Match(logLine);
+         if (m.Success)
+         {
+            string logTime = m.Groups[1].Value + " " + m.Groups[2].Value;
+
+            // normalize: replace '/' with '-'
+            logTime = logTime.Replace('/', '-');
+
+            // replace space between minutes and seconds with ':'
+            // "2026-03-31 10:36 21.192" -> "2026-03-31 10:36:21.192"
+            if (logTime.Length >= 17)
+            {
+               logTime = logTime.Remove(16, 1).Insert(16, ":");
+            }
+
+            return logTime;
+         }
+
+         return base.tsTimestamp();
+      }
+
+      protected override string hResult()
+      {
+         // Use the hex error code as hResult
+         Match m = errorRegex.Match(logLine);
+         if (m.Success)
+         {
+            return m.Groups[2].Value;
+         }
+
+         return base.hResult();
+      }
+   }
+}

--- a/src/SPLogLine/SPLine.cs
+++ b/src/SPLogLine/SPLine.cs
@@ -200,6 +200,9 @@ namespace LogLineHandler
 
       WFS_SYSEVENT,
 
+      /* Device-level errors (packed binary, not XFS protocol) */
+      DEVICE_ERROR,
+
       /* ERROR */
       Error
    }
@@ -464,6 +467,11 @@ namespace LogLineHandler
 
       static Regex WFPOpen = new Regex("(XFS_CMD[a-zA-Z0-9 ]*)(OPEN[a-zA-Z0-9 ]*)(hResult\\[(\\d+)\\] = WFPOpen)");
       static Regex WFPClose = new Regex("(XFS_CMD[a-zA-Z0-9 ]*)(CLOSE[a-zA-Z0-9 ]*)(hResult\\[(\\d+)\\] = WFPClose)");
+
+      /* Device-level errors */
+      private static readonly Regex deviceErrorRegex = new Regex(
+         @"Fail(?:ed)? to \w+ with.*?error=\[([A-Fa-f0-9]+)\]",
+         RegexOptions.Compiled);
 
       // implementations of the ILogLine interface
       public string Timestamp { get; set; }
@@ -948,6 +956,15 @@ namespace LogLineHandler
          if (logLine.Contains("lpbDescription"))
          {
             return new SPLine(logFileHandler, logLine, XFSType.WFS_SYSEVENT);
+         }
+
+         /* Device-level errors (packed binary, not XFS protocol) */
+         if (logLine.Contains("Fail to ") || logLine.Contains("Failed to "))
+         {
+            if (deviceErrorRegex.Match(logLine).Success)
+            {
+               return new SPDEVICEERROR(logFileHandler, logLine, XFSType.DEVICE_ERROR);
+            }
          }
 
          return new SPLine(logFileHandler, logLine, XFSType.None);

--- a/src/SPLogLine/SPLogLine.csproj
+++ b/src/SPLogLine/SPLogLine.csproj
@@ -41,6 +41,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SPDEVICEERROR.cs" />
     <Compile Include="WFSCUINFO.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SPLine.cs" />


### PR DESCRIPTION
Detect and parse device-level error lines (CCCIMDev, CBRM20) that were previously falling through SPLine.Factory() as XFSType.None. These packed binary lines follow the pattern "Fail(ed) to <operation> with error=[hex]" and report CIM/CDM hardware failures (_Retract, _DepositCheck, _Initialize, Dispense) with hex error codes.

Changes:
- Add XFSType.DEVICE_ERROR enum value
- Add SPDEVICEERROR class (src/SPLogLine/) with custom timestamp and error code extraction from packed binary format, overriding tsTimestamp() and hResult() since these lines lack standard XFS field structure
- Add deviceErrorRegex and detection in SPLine.Factory() before the XFSType.None fallback
- Add DEVICE_ERROR case to CIMTable (Deposit table, uses errcode column), CDMTable (Dispense table), and DEVTable (Status table, routes by class name to CIM/CDM column)

Emitting to all three tables initially to evaluate where the data is most useful before refining routing by device context.