### PR TITLE
fix: Add PinPad command and error visibility to OverSummary pin column

### DIFF
--- a/src/APLine/APLine.cs
+++ b/src/APLine/APLine.cs
@@ -67,6 +67,9 @@ namespace LogLineHandler
       APLOG_PIN_PINBLOCK_FAILED,
       APLOG_PIN_TIMEOUT,
       APLOG_PIN_READCOMPLETE,
+      APLOG_PIN_EXECUTECOMMAND,
+      APLOG_PIN_XFSCODE_ERROR,
+      APLOG_PIN_FATALERROR,
 
       APLOG_DISPLAYLOAD,
       APLOG_SCREENWINDOW, 
@@ -517,6 +520,23 @@ namespace LogLineHandler
 
 
          /* [Pinpad              */
+
+         if (logLine.Contains("[Pinpad") && logLine.Contains("ExecuteDeviceCommand") && logLine.Contains("\"command\""))
+         {
+            if (logLine.Contains("\"ReadData\""))
+               return null;
+            return new APLinePinCommand(logFileHandler, logLine);
+         }
+
+         if (logLine.Contains("[Pinpad") && logLine.Contains("LogXfsCode") && logLine.Contains(" ERROR ["))
+            return new APLineField(logFileHandler, logLine, APLogType.APLOG_PIN_XFSCODE_ERROR);
+
+         if (logLine.Contains("[Pinpad") && logLine.Contains("OnFatalError"))
+            return new APLine(logFileHandler, logLine, APLogType.APLOG_PIN_FATALERROR);
+
+         /* [Pinpad.OnFatalError] */
+         if (logLine.Contains("[Pinpad") && logLine.Contains("OnFatalError"))
+            return new APLine(logFileHandler, logLine, APLogType.APLOG_PIN_FATALERROR);
          if ((logLine.Contains("[Pinpad") || logLine.Contains("[RetailPinpad")) && logLine.Contains("Open"))
             return new APLine(logFileHandler, logLine, APLogType.APLOG_PIN_OPEN);
 

--- a/src/APLine/APLineCommand.cs
+++ b/src/APLine/APLineCommand.cs
@@ -1,0 +1,37 @@
+﻿using Contract;
+
+namespace LogLineHandler
+{
+   /// <summary>
+   /// Parses a [Pinpad.ExecuteDeviceCommand] line and extracts the PIN command name.
+   /// Example:
+   ///   INFO [...] [Pinpad.ExecuteDeviceCommand] [TID:3] [DEVICE] { "device": "PIN", "command": "ReadPIN", ... }
+   /// Extracted field: "ReadPIN"
+   /// </summary>
+   public class APLinePinCommand : APLine
+   {
+      public string field = string.Empty;
+
+      public APLinePinCommand(ILogFileHandler parent, string logLine) : base(parent, logLine, APLogType.APLOG_PIN_EXECUTECOMMAND)
+      {
+      }
+
+      protected override void Initialize()
+      {
+         base.Initialize();
+
+         // Extract the value of "command": "..." from the JSON payload
+         string lookFor = "\"command\": \"";
+         int idx = logLine.IndexOf(lookFor);
+         if (idx != -1)
+         {
+            int start = idx + lookFor.Length;
+            int end = logLine.IndexOf("\"", start);
+            if (end != -1)
+            {
+               field = logLine.Substring(start, end - start);
+            }
+         }
+      }
+   }
+}

--- a/src/APLine/APLineField.cs
+++ b/src/APLine/APLineField.cs
@@ -174,6 +174,17 @@ namespace LogLineHandler
                   }
                   break;
                }
+            case APLogType.APLOG_PIN_XFSCODE_ERROR:
+               {
+                  // e.g. "Pinpad.CMD_PIN_GET_CERTIFICATE returned -400. WFS_ERR_PIN_KEYNOTFOUND | The specified key was not found."
+                  lookFor = "Pinpad.";
+                  idx = logLine.LastIndexOf(lookFor);
+                  if (idx != -1)
+                  {
+                     field = logLine.Substring(idx + lookFor.Length).Trim().Trim(trimChars);
+                  }
+                  break;
+               }
             case APLogType.APLOG_DISPLAYLOAD:
                {
                   lookFor = "for screen ";

--- a/src/APLine/APLogLine.csproj
+++ b/src/APLine/APLogLine.csproj
@@ -73,6 +73,7 @@
   <ItemGroup>
     <Compile Include="AddKey.cs" />
     <Compile Include="APLine.cs" />
+    <Compile Include="APLineCommand.cs" />
     <Compile Include="APLineField.cs" />
     <Compile Include="CashDispenser\CashDispener.cs" />
     <Compile Include="CashDispenser\CashDispenser_DispenseSyncAsync.cs" />

--- a/src/OverView/OverTable.cs
+++ b/src/OverView/OverTable.cs
@@ -642,6 +642,33 @@ namespace OverView
                         break;
                      }
 
+                  case APLogType.APLOG_PIN_EXECUTECOMMAND:
+                     {
+                        base.ProcessRow(logLine);
+                        if (apLogLine is APLinePinCommand pinCmd)
+                        {
+                           APLINE(pinCmd, "pin", pinCmd.field);
+                        }
+                        break;
+                     }
+
+                  case APLogType.APLOG_PIN_XFSCODE_ERROR:
+                     {
+                        base.ProcessRow(logLine);
+                        if (apLogLine is APLineField lineField)
+                        {
+                           APLINE2(lineField, "pin", "ERROR", "error", lineField.field);
+                        }
+                        break;
+                     }
+
+                  case APLogType.APLOG_PIN_FATALERROR:
+                     {
+                        base.ProcessRow(logLine);
+                        APLINE2(apLogLine, "pin", "FATAL ERROR", "error", "OnFatalError");
+                        break;
+                     }
+
                   /* device */
 
                   case APLogType.APLOG_CDM_ONLINE:


### PR DESCRIPTION
Previously the pin column in OverSummary showed only "PCI EPP" and "TR34" at startup, leaving the column blank for the rest of the session. This made it impossible to follow PinPad activity at a glance.

New enum values, Factory detection, and OverTable cases added for:

  APLOG_PIN_EXECUTECOMMAND  - [Pinpad.ExecuteDeviceCommand] lines. Extracts
                              the command name from the JSON payload and emits
                              it to the pin column. ReadData is suppressed as
                              it is high-frequency polling noise (MINDigits=0,
                              ActiveKeys=CANCEL only). Implemented as a new
                              APLinePinCommand class (own file, per convention)
                              using IndexOf/Substring extraction consistent
                              with sibling APLine subclasses.

  APLOG_PIN_XFSCODE_ERROR   - [Pinpad.LogXfsCode] ERROR lines. Extracts the
                              command name, return code, and WFS error constant
                              from the payload. Emits "ERROR" to the pin column
                              and the full detail to the error column so the
                              reader sees it from either perspective.

  APLOG_PIN_FATALERROR      - [Pinpad.OnFatalError] WARN lines. Emits "FATAL
                              ERROR" to pin and "OnFatalError" to error.

All three Factory checks are inserted before the existing generic [Pinpad open/close checks to ensure correct precedence.