### PR TITLE
feat: add English translation for usPStatus codes to NHCDM

### DIFF
--- a/src/NHCDMView/NHCDMTable.cs
+++ b/src/NHCDMView/NHCDMTable.cs
@@ -72,6 +72,27 @@ namespace NHCDMView
 
          try
          {
+            // A D D  E N G L I S H
+            string[,] colKeyMap = new string[1, 2]
+            {
+               { "status", "usPStatus" }
+            };
+            foreach (DataTable dTable in dTableSet.Tables)
+            {
+               if (dTable.TableName.StartsWith("NHCDM-"))
+               {
+                  tableName = dTable.TableName;
+                  AddEnglishToTable(tableName, colKeyMap);
+               }
+            }
+         }
+         catch (Exception e)
+         {
+            ctx.ConsoleWriteLogLine(String.Format("Exception adding English to {0} table - {1}", tableName, e.Message));
+         }
+
+         try
+         {
             // R E N A M E  C A S S E T T E S
             DataRow[] allRows = dTableSet.Tables["Summary"].Select();
             foreach (DataTable dTable in dTableSet.Tables)

--- a/src/NHCDMView/NHCDMView.xml
+++ b/src/NHCDMView/NHCDMView.xml
@@ -9,4 +9,77 @@
   <Summary><file></file><time></time><error></error><cstnumber></cstnumber><cstid></cstid><currency></currency><denom></denom><noterev></noterev><calibration></calibration><missingcheck></missingcheck><initial></initial><serial></serial></Summary>
   <Summary><file></file><time></time><error></error><cstnumber></cstnumber><cstid></cstid><currency></currency><denom></denom><noterev></noterev><calibration></calibration><missingcheck></missingcheck><initial></initial><serial></serial></Summary>
   <Summary><file></file><time></time><error></error><cstnumber></cstnumber><cstid></cstid><currency></currency><denom></denom><noterev></noterev><calibration></calibration><missingcheck></missingcheck><initial></initial><serial></serial></Summary>
+
+<!-- usPStatus -->
+
+  <Messages>
+    <type>usPStatus</type>
+    <code>0</code>
+    <brief>ok</brief>
+    <description>The cash unit is in a good state</description>
+  </Messages>   
+
+  <Messages>
+    <type>usPStatus</type>
+    <code>1</code>
+    <brief>full</brief>
+    <description>The cash unit is full.</description>
+  </Messages>   
+
+  <Messages>
+    <type>usPStatus</type>
+    <code>2</code>
+    <brief>high</brief>
+    <description>The cash unit is almost full (i.e. reached or exceeded the threshold defined by ulMaximum).</description>
+  </Messages>   
+
+  <Messages>
+    <type>usPStatus</type>
+    <code>3</code>
+    <brief>low</brief>
+    <description>The cash unit is almost empty (i.e. reached or below the threshold defined by ulMinimum). </description>
+  </Messages>   
+
+  <Messages>
+    <type>usPStatus</type>
+    <code>4</code>
+    <brief>empty</brief>
+    <description>The cash unit is empty, or insufficient items in the cash unit are preventing further dispense operations.</description>
+  </Messages>   
+
+  <Messages>
+    <type>usPStatus</type>
+    <code>5</code>
+    <brief>inop</brief>
+    <description>The cash unit is inoperative.</description>
+  </Messages>   
+
+  <Messages>
+    <type>usPStatus</type>
+    <code>6</code>
+    <brief>missing</brief>
+    <description>The cash unit is missing.</description>
+  </Messages>
+
+  <Messages>
+    <type>usPStatus</type>
+    <code>7</code>
+    <brief>noval</brief>
+    <description>The values of the specified cash unit are not available</description>
+  </Messages>   
+
+  <Messages>
+    <type>usPStatus</type>
+    <code>8</code>
+    <brief>noref</brief>
+    <description>There is no reference value available for the notes in this cash unit. The cash unit has not been calibrated.</description>
+  </Messages>   
+
+  <Messages>
+    <type>usPStatus</type>
+    <code>9</code>
+    <brief>manip</brief>
+    <description>The cash unit has been inserted when the device was not in the exchange state. This cash unit cannot be dispensed from.</description>
+  </Messages>
+  
 </NHCDMView>

--- a/src/NHCDMView/NHCDMView.xsd
+++ b/src/NHCDMView/NHCDMView.xsd
@@ -40,6 +40,7 @@
               <xs:element name="noterev"      type="xs:string" minOccurs="0" />
               <xs:element name="calibration"  type="xs:string" minOccurs="0" />
               <xs:element name="missingcheck" type="xs:string" minOccurs="0" />
+              <xs:element name="comment"      type="xs:string" minOccurs="0" /> 
             </xs:sequence>
           </xs:complexType>
         </xs:element>
@@ -61,6 +62,7 @@
               <xs:element name="noterev"      type="xs:string" minOccurs="0" />
               <xs:element name="calibration"  type="xs:string" minOccurs="0" />
               <xs:element name="missingcheck" type="xs:string" minOccurs="0" />
+              <xs:element name="comment"      type="xs:string" minOccurs="0" />
             </xs:sequence>
           </xs:complexType>
         </xs:element>
@@ -82,6 +84,7 @@
               <xs:element name="noterev"      type="xs:string" minOccurs="0" />
               <xs:element name="calibration"  type="xs:string" minOccurs="0" />
               <xs:element name="missingcheck" type="xs:string" minOccurs="0" />
+              <xs:element name="comment"      type="xs:string" minOccurs="0" />
             </xs:sequence>
           </xs:complexType>
         </xs:element>
@@ -103,6 +106,7 @@
               <xs:element name="noterev"      type="xs:string" minOccurs="0" />
               <xs:element name="calibration"  type="xs:string" minOccurs="0" />
               <xs:element name="missingcheck" type="xs:string" minOccurs="0" />
+              <xs:element name="comment"      type="xs:string" minOccurs="0" />
             </xs:sequence>
           </xs:complexType>
         </xs:element>
@@ -124,6 +128,7 @@
               <xs:element name="noterev"      type="xs:string" minOccurs="0" />
               <xs:element name="calibration"  type="xs:string" minOccurs="0" />
               <xs:element name="missingcheck" type="xs:string" minOccurs="0" />
+              <xs:element name="comment"      type="xs:string" minOccurs="0" />
             </xs:sequence>
           </xs:complexType>
         </xs:element>
@@ -145,6 +150,7 @@
               <xs:element name="noterev"      type="xs:string" minOccurs="0" />
               <xs:element name="calibration"  type="xs:string" minOccurs="0" />
               <xs:element name="missingcheck" type="xs:string" minOccurs="0" />
+              <xs:element name="comment"      type="xs:string" minOccurs="0" />
             </xs:sequence>
           </xs:complexType>
         </xs:element>
@@ -166,6 +172,7 @@
               <xs:element name="noterev"      type="xs:string" minOccurs="0" />
               <xs:element name="calibration"  type="xs:string" minOccurs="0" />
               <xs:element name="missingcheck" type="xs:string" minOccurs="0" />
+              <xs:element name="comment"      type="xs:string" minOccurs="0" />
             </xs:sequence>
           </xs:complexType>
         </xs:element>
@@ -187,6 +194,7 @@
               <xs:element name="noterev"      type="xs:string" minOccurs="0" />
               <xs:element name="calibration"  type="xs:string" minOccurs="0" />
               <xs:element name="missingcheck" type="xs:string" minOccurs="0" />
+              <xs:element name="comment"      type="xs:string" minOccurs="0" />
             </xs:sequence>
           </xs:complexType>
         </xs:element>
@@ -208,6 +216,7 @@
               <xs:element name="noterev"      type="xs:string" minOccurs="0" />
               <xs:element name="calibration"  type="xs:string" minOccurs="0" />
               <xs:element name="missingcheck" type="xs:string" minOccurs="0" />
+              <xs:element name="comment"      type="xs:string" minOccurs="0" />
             </xs:sequence>
           </xs:complexType>
         </xs:element>


### PR DESCRIPTION
Add usPStatus message definitions to NHCDMView.xml covering status codes 0-9 (ok, full, high, low, empty, inop, missing, noval, noref, manip).

Add comment column to NHCDM-x table definitions in NHCDMView.xsd to support AddEnglish output.

Wire AddEnglish in NHCDMTable.WriteExcelFile to translate status column using usPStatus lookup, running before the rename block while tables are still named NHCDM-x.

Fix malformed xsd — missing '/>' on comment element definition.