### PR TITLE
fix: improve version reporting and add view options to help output

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -50,6 +50,12 @@
   <PropertyGroup>
     <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(GitVersion_AssemblySemVer)' != ''">
+    <AssemblyVersion>$(GitVersion_AssemblySemVer)</AssemblyVersion>
+    <FileVersion>$(GitVersion_AssemblySemFileVer)</FileVersion>
+    <InformationalVersion>$(GitVersion_InformationalVersion)</InformationalVersion>
+  </PropertyGroup>
 
   <Target Name="Package" />
 

--- a/src/splogparser/Program.cs
+++ b/src/splogparser/Program.cs
@@ -75,6 +75,7 @@ namespace splogparser
              .WithNotParsed(HandleParseError);
       }
 
+
       private static void HandleParseError(IEnumerable<Error> errs)
       {
          Console.WriteLine($"Running SplogParser version {VersionInfo.Current}");
@@ -88,10 +89,39 @@ namespace splogparser
          if (errs.IsHelp())
          {
             Console.WriteLine("Help Request");
+            PrintVerbHelp();
             return;
          }
+
          Console.WriteLine("Parser Fail");
+         PrintVerbHelp();
       }
+
+      private static void PrintVerbHelp()
+      {
+         Console.WriteLine();
+         Console.WriteLine("-s (--sp) View Options:");
+         Console.WriteLine("  CDM      Cash Dispense Module status, dispense operations and counts");
+         Console.WriteLine("  PHY      Physical cash dispenser cassettes - summary and time-series");
+         Console.WriteLine("  NHCDM    NH CDM physical cassette serial numbers and swap history (NH hardware only)");
+         Console.WriteLine("  CIM      Cash-In Module status, deposit operations and counts");
+         Console.WriteLine("  DEV      Device status over time");
+         Console.WriteLine("  Extra    lpszExtra values from device status - good for error codes");
+         Console.WriteLine("  IDC      Card reader status and inserts");
+         Console.WriteLine("  IPM      Check depositor status, deposits and counts");
+         Console.WriteLine("  PIN      PinPad status");
+         Console.WriteLine("  SIU      Status and indicator status (safe open/close, supervisor)");
+         Console.WriteLine("  *        All of the above");
+         Console.WriteLine();
+         Console.WriteLine("-a (--ap) View Options:");
+         Console.WriteLine("  Over     Overview of transactions");
+         Console.WriteLine("  Disp     Cash dispense");
+         Console.WriteLine("  EJ       EJ insert commands");
+         Console.WriteLine("  XmlParam Config files and parameters in table form");
+         Console.WriteLine("  AddKey   Keys loaded on start-up");
+         Console.WriteLine("  *        All of the above");
+      }
+
 
       private static void Run(Options opts)
       {

--- a/src/splogparser/Version.cs
+++ b/src/splogparser/Version.cs
@@ -1,8 +1,10 @@
-// Auto-generated version file
+﻿// Auto-generated version file
 namespace SplogParser
 {
-    public static class VersionInfo
-    {
-        public const string Current = "8.0.21";
-    }
+   public static class VersionInfo
+   {
+      public static string Current =>
+          System.Reflection.Assembly.GetExecutingAssembly()
+              .GetName().Version.ToString();
+   }
 }


### PR DESCRIPTION
VersionInfo.cs
- Replace hardcoded version string "8.0.21" with dynamic assembly version read via Assembly.GetExecutingAssembly().GetName().Version
- Version now reflects the actual build version stamped by GitVersion rather than a stale constant

Directory.Build.props
- Wire GitVersion assembly versioning into MSBuild so CI builds stamp the correct version into all assemblies
- AssemblyVersion, FileVersion and InformationalVersion now set from GitVersion_AssemblySemVer, GitVersion_AssemblySemFileVer and GitVersion_InformationalVersion respectively
- Local builds without GitVersion continue to use default 1.0.0.0

Program.cs
- Add PrintVerbHelp() method listing all supported view options for -s (--sp) and -a (--ap) parse types with descriptions
- PrintVerbHelp() called from both IsHelp() and Parser Fail paths so running splogparser with no arguments or --help shows the full grammar including view options
- Previously only the top-level argument grammar was shown with no indication of what values CDM, PHY, NHCDM, CIM etc. mean