### PR TITLE
feat: OverView - add per-day resource usage wall-clock charts

### DIFF
--- a/src/APLine/APLine.cs
+++ b/src/APLine/APLine.cs
@@ -765,6 +765,12 @@ namespace LogLineHandler
 
          ///* status - shutter, position, stacker, transport */
 
+         /* RESOURCE USAGE : periodic memory / handle snapshot lines (APLOG_MEMORY) */
+         if (logLine.Contains("Memory") || logLine.Contains("size:") || logLine.Contains("count:"))
+         {
+            ILogLine iLine = MemoryLine.Factory(logFileHandler, logLine);
+            if (iLine != null) return iLine;
+         }
 
          /* Account */
 

--- a/src/APLine/APLogLine.csproj
+++ b/src/APLine/APLogLine.csproj
@@ -114,6 +114,7 @@
     <Compile Include="EJInsert.cs" />
     <Compile Include="LogTransactionData\LogTransactionData.cs" />
     <Compile Include="MachineInfo.cs" />
+    <Compile Include="MemoryLine.cs" />
     <Compile Include="NDC\Atm2Host\Atm2Host.cs" />
     <Compile Include="NDC\Atm2Host\Atm2Host11.cs" />
     <Compile Include="NDC\Atm2Host\Atm2Host12.cs" />

--- a/src/APLine/MemoryLine.cs
+++ b/src/APLine/MemoryLine.cs
@@ -1,0 +1,81 @@
+﻿using System.Text.RegularExpressions;
+using Contract;
+
+namespace LogLineHandler
+{
+   public enum MemoryMetric
+   {
+      None,
+      DateTimeCount,    /* Date  Time  :6/3/2026 12:49:16 PM   count:1276 */
+      Memory,           /* Memory      : 479,989,760                      */
+      VMSize,           /* VM      size:1,457,496,064                     */
+      PrivateSize,      /* Private size: 498,593,792                      */
+      HandleCount       /* Handle count:5947                              */
+   }
+
+   /// <summary>
+   /// One line of a periodic resource usage snapshot written by the application.
+   /// A full snapshot is a group of five consecutive lines (date/time + count,
+   /// memory, VM size, private size, handle count) sharing a timestamp.
+   /// </summary>
+   public class MemoryLine : APLine
+   {
+      /// <summary>Which metric this line carries.</summary>
+      public MemoryMetric metric { get; private set; }
+
+      /// <summary>Parsed numeric value: bytes for size metrics, a count otherwise.</summary>
+      public long value { get; private set; }
+
+      public MemoryLine(ILogFileHandler parent, string logLine, MemoryMetric metric)
+         : base(parent, logLine, APLogType.APLOG_MEMORY)
+      {
+         this.metric = metric;
+         this.value = ParseValue(logLine);
+      }
+
+      /// <summary>
+      /// The value is the digits (possibly comma separated) following the last ':' in the line.
+      /// This holds for all five metric line formats.
+      /// </summary>
+      private static long ParseValue(string logLine)
+      {
+         int lastColon = logLine.LastIndexOf(':');
+         if (lastColon < 0 || lastColon == logLine.Length - 1)
+         {
+            return 0;
+         }
+
+         string raw = logLine.Substring(lastColon + 1).Trim().Replace(",", "");
+
+         Match m = Regex.Match(raw, @"^\d+");
+         if (!m.Success)
+         {
+            return 0;
+         }
+
+         long result = 0;
+         long.TryParse(m.Value, out result);
+         return result;
+      }
+
+      public static ILogLine Factory(ILogFileHandler logFileHandler, string logLine)
+      {
+         if (Regex.IsMatch(logLine, @"Date\s+Time\s+:.+count:\d+"))
+            return new MemoryLine(logFileHandler, logLine, MemoryMetric.DateTimeCount);
+
+         if (Regex.IsMatch(logLine, @"\bMemory\s+:\s*[\d,]+"))
+            return new MemoryLine(logFileHandler, logLine, MemoryMetric.Memory);
+
+         if (Regex.IsMatch(logLine, @"\bVM\s+size:\s*[\d,]+"))
+            return new MemoryLine(logFileHandler, logLine, MemoryMetric.VMSize);
+
+         if (Regex.IsMatch(logLine, @"\bPrivate size:\s*[\d,]+"))
+            return new MemoryLine(logFileHandler, logLine, MemoryMetric.PrivateSize);
+
+         if (Regex.IsMatch(logLine, @"\bHandle count:\s*\d+"))
+            return new MemoryLine(logFileHandler, logLine, MemoryMetric.HandleCount);
+
+         return null;
+      }
+   }
+}

--- a/src/APLogLineTests/APLogLineTests.csproj
+++ b/src/APLogLineTests/APLogLineTests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="APLogHandler_IdentifyLines_NDC_Tests.cs" />
     <Compile Include="APLogHandler_IdentifyLines_Device_Tests.cs" />
     <Compile Include="CreateTextStreamReaderMock.cs" />
+    <Compile Include="MemoryLineTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="APLogHandler_IdentifyLines_Tests.cs" />
     <Compile Include="APLogHandler_ReadLine_Tests.cs" />

--- a/src/APLogLineTests/MemoryLineTests.cs
+++ b/src/APLogLineTests/MemoryLineTests.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using LogLineHandler;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace APLogLineTests
+{
+   /// <summary>
+   /// Parser tests for the five resource-snapshot line formats (APLOG_MEMORY).
+   ///
+   /// NOTE: the 'handler' field below mirrors however the existing
+   /// APLineFieldTests constructs its ILogFileHandler. If that test uses a
+   /// different field name or factory helper, reuse it here verbatim - the
+   /// only requirement is a non-null handler whose ParseType is AP.
+   /// </summary>
+   [TestClass]
+   public class MemoryLineTests
+   {
+      private const string DateTimeLine = "[2026-06-03 12:49:16-648] Date  Time  :6/3/2026 12:49:16 PM   count:1276";
+      private const string MemoryLine_ = "[2026-06-03 12:49:16-652] Memory      : 479,989,760";
+      private const string VMSizeLine = "[2026-06-03 12:49:16-652] VM      size:1,457,496,064";
+      private const string PrivateLine = "[2026-06-03 12:49:16-652] Private size: 498,593,792";
+      private const string HandleLine = "[2026-06-03 12:49:16-652] Handle count:5947";
+
+      [TestMethod]
+      public void Factory_Identifies_All_Five_Metrics()
+      {
+         Assert.AreEqual(MemoryMetric.DateTimeCount, ((MemoryLine)MemoryLine.Factory(null, DateTimeLine)).metric);
+         Assert.AreEqual(MemoryMetric.Memory, ((MemoryLine)MemoryLine.Factory(null, MemoryLine_)).metric);
+         Assert.AreEqual(MemoryMetric.VMSize, ((MemoryLine)MemoryLine.Factory(null, VMSizeLine)).metric);
+         Assert.AreEqual(MemoryMetric.PrivateSize, ((MemoryLine)MemoryLine.Factory(null, PrivateLine)).metric);
+         Assert.AreEqual(MemoryMetric.HandleCount, ((MemoryLine)MemoryLine.Factory(null, HandleLine)).metric);
+      }
+
+      [TestMethod]
+      public void Factory_Returns_Null_For_NonResourceLine()
+      {
+         // A normal AP line that happens to contain 'Memory' must not be claimed.
+         string notResource = "[2026-06-03 12:49:16-652] [SomeClass.Method] Low memory warning cleared";
+         Assert.IsNull(MemoryLine.Factory(null, notResource));
+      }
+
+      [TestMethod]
+      public void DateTimeCount_Parses_Count_Not_TimeOfDay()
+      {
+         // The trap: LastIndexOf(':') must skip the 12:49:16 colons and land on count:1276.
+         MemoryLine line = (MemoryLine)MemoryLine.Factory(null, DateTimeLine);
+         Assert.AreEqual(1276L, line.value);
+      }
+
+      [TestMethod]
+      public void Size_Metrics_Parse_CommaSeparated_Bytes()
+      {
+         Assert.AreEqual(479989760L, ((MemoryLine)MemoryLine.Factory(null, MemoryLine_)).value);
+         Assert.AreEqual(1457496064L, ((MemoryLine)MemoryLine.Factory(null, VMSizeLine)).value);
+         Assert.AreEqual(498593792L, ((MemoryLine)MemoryLine.Factory(null, PrivateLine)).value);
+         Assert.AreEqual(5947L, ((MemoryLine)MemoryLine.Factory(null, HandleLine)).value);
+      }
+
+      [TestMethod]
+      public void Timestamp_Is_Extracted_From_Leading_Bracket()
+      {
+         MemoryLine line = (MemoryLine)MemoryLine.Factory(null, PrivateLine);
+         Assert.AreEqual("2026-06-03 12:49:16.652", line.Timestamp);
+      }
+
+      [TestMethod]
+      public void APLine_Factory_Routes_Resource_Lines_To_MemoryLine()
+      {
+         // End-to-end through the real AP dispatcher.
+         Assert.IsInstanceOfType(APLine.Factory(null, MemoryLine_), typeof(MemoryLine));
+         Assert.IsInstanceOfType(APLine.Factory(null, HandleLine), typeof(MemoryLine));
+      }
+   }
+}

--- a/src/OverView/OverTable.cs
+++ b/src/OverView/OverTable.cs
@@ -15,6 +15,9 @@ namespace OverView
       string FITSwitchForeignNextStateNumbers = string.Empty;
       string FITSwitchOtherNextStateNumbers = string.Empty;
 
+      /// <summary>Resource row being assembled from a group of snapshot lines.</summary>
+      private DataRow _pendingResourceRow = null;
+
       /// <summary>
       /// constructor
       /// </summary>
@@ -34,6 +37,14 @@ namespace OverView
       {
          if (dTableSet.Tables.Contains("Summary"))
             return dTableSet.Tables["Summary"];
+         return null;
+      }
+
+      /// <summary>Accessor for the raw Resource snapshot table.</summary>
+      public DataTable GetResourceTable()
+      {
+         if (dTableSet.Tables.Contains("Resource"))
+            return dTableSet.Tables["Resource"];
          return null;
       }
 
@@ -251,6 +262,151 @@ namespace OverView
          allDataRange.Columns.AutoFit();
       }
 
+      /// <summary>The 32-bit user address-space ceiling in MB. 4096 assumes XTM is
+      /// LargeAddressAware (its VM size exceeding 2 GB proves it is); use 2048 for a
+      /// non-LAA build.</summary>
+      private const double Win32AddressCeilingMB = 4096.0;
+
+      /// <summary>
+      /// Writes the ResourceWallClock worksheet: per day, a 96-slot (15-minute)
+      /// grid of resource metrics with four line charts (memory, VM size, private
+      /// bytes, handles) over a fixed 24-hour x-axis. VM and private charts carry a
+      /// dashed reference line at the 32-bit address-space ceiling.
+      /// </summary>
+      public void WriteResourceWallClockExcel(List<ResourceDaySlots> results)
+      {
+         if (results == null || results.Count == 0)
+            return;
+
+         string excelFileName = ctx.ExcelFileName;
+         ctx.ConsoleWriteLogLine("WriteResourceWallClockExcel: Adding resource charts to " + excelFileName);
+
+         Excel.Application excelApp = new Excel.Application
+         {
+            Visible = false,
+            DisplayAlerts = false
+         };
+
+         Excel.Workbook activeBook = excelApp.Workbooks.Open(excelFileName);
+
+         try
+         {
+            Excel._Worksheet worksheet = (Excel._Worksheet)activeBook.Sheets.Add(After: activeBook.Sheets[activeBook.Sheets.Count]);
+            worksheet.Name = "ResourceWallClock";
+
+            string[] metricTitles = { "Memory (MB)", "VM Size (MB)", "Private Size (MB)", "Handles" };
+            int[] metricColumns = { 2, 3, 4, 5 };
+            int[] metricColors = { 0x00DD8A37, 0x00759E1D, 0x00004AE2, 0x001775BA };  // BGR
+
+            // Rectangular charts: 2:1 (wider on x than y).
+            double chartW = 480, chartH = 240, hGap = 500, vGap = 260;
+
+            int currentRow = 1;
+
+            foreach (ResourceDaySlots day in results)
+            {
+               int headerRow = currentRow;
+               int dataFirst = headerRow + 1;
+               int dataLast = headerRow + ResourceDaySlots.SlotCount;
+
+               worksheet.Cells[headerRow, 1] = day.Date.ToString("yyyy-MM-dd");
+               ((Excel.Range)worksheet.Cells[headerRow, 1]).Font.Bold = true;
+               worksheet.Cells[headerRow, 2] = "Memory";
+               worksheet.Cells[headerRow, 3] = "VM";
+               worksheet.Cells[headerRow, 4] = "Private";
+               worksheet.Cells[headerRow, 5] = "Handles";
+
+               object[,] block = new object[ResourceDaySlots.SlotCount, 5];
+               for (int slot = 0; slot < ResourceDaySlots.SlotCount; slot++)
+               {
+                  block[slot, 0] = ResourceDaySlots.SlotLabel(slot);
+                  block[slot, 1] = day.Memory[slot].HasValue ? (object)day.Memory[slot].Value : null;
+                  block[slot, 2] = day.VmSize[slot].HasValue ? (object)day.VmSize[slot].Value : null;
+                  block[slot, 3] = day.Private[slot].HasValue ? (object)day.Private[slot].Value : null;
+                  block[slot, 4] = day.Handles[slot].HasValue ? (object)day.Handles[slot].Value : null;
+               }
+               worksheet.Range[worksheet.Cells[dataFirst, 1], worksheet.Cells[dataLast, 5]].Value2 = block;
+
+               Excel.Range anchor = (Excel.Range)worksheet.Cells[headerRow, 7];
+               double baseLeft = (double)anchor.Left;
+               double baseTop = (double)anchor.Top;
+
+               Excel.Range xValues = worksheet.Range[worksheet.Cells[dataFirst, 1], worksheet.Cells[dataLast, 1]];
+               Excel.ChartObjects chartObjects = (Excel.ChartObjects)worksheet.ChartObjects(Type.Missing);
+
+               for (int m = 0; m < metricColumns.Length; m++)
+               {
+                  bool addWall = (m == 1 || m == 2);   // VM Size, Private Size
+
+                  double left = baseLeft + ((m % 2) * hGap);
+                  double top = baseTop + ((m / 2) * vGap);
+
+                  Excel.ChartObject chartObject = chartObjects.Add(left, top, chartW, chartH);
+                  Excel.Chart chart = chartObject.Chart;
+                  chart.ChartType = Excel.XlChartType.xlLine;
+
+                  Excel.SeriesCollection seriesCollection = (Excel.SeriesCollection)chart.SeriesCollection(Type.Missing);
+
+                  Excel.Series series = seriesCollection.NewSeries();
+                  series.XValues = xValues;
+                  series.Values = worksheet.Range[worksheet.Cells[dataFirst, metricColumns[m]], worksheet.Cells[dataLast, metricColumns[m]]];
+                  series.Name = metricTitles[m];
+                  series.Border.Color = metricColors[m];
+                  series.Border.Weight = Excel.XlBorderWeight.xlMedium;
+                  series.MarkerStyle = Excel.XlMarkerStyle.xlMarkerStyleNone;
+
+                  if (addWall)
+                  {
+                     double[] ceiling = new double[ResourceDaySlots.SlotCount];
+                     for (int k = 0; k < ceiling.Length; k++)
+                     {
+                        ceiling[k] = Win32AddressCeilingMB;
+                     }
+
+                     Excel.Series wallSeries = seriesCollection.NewSeries();
+                     wallSeries.XValues = xValues;
+                     wallSeries.Values = ceiling;
+                     wallSeries.Name = "32-bit limit";
+                     wallSeries.Border.Color = 0x000000FF;   // red (BGR)
+                     wallSeries.Border.LineStyle = Excel.XlLineStyle.xlDash;
+                     wallSeries.MarkerStyle = Excel.XlMarkerStyle.xlMarkerStyleNone;
+                  }
+
+                  string title = day.Date.ToString("yyyy-MM-dd") + "  " + metricTitles[m];
+                  if (addWall)
+                  {
+                     title += "  (red dash = 4 GB cap)";
+                  }
+                  chart.HasTitle = true;
+                  chart.ChartTitle.Text = title;
+                  chart.HasLegend = false;
+
+                  Excel.Axis categoryAxis = (Excel.Axis)chart.Axes(Excel.XlAxisType.xlCategory, Excel.XlAxisGroup.xlPrimary);
+                  categoryAxis.TickLabelSpacing = 8;
+                  categoryAxis.TickLabels.Orientation = (Excel.XlTickLabelOrientation)45;
+
+                  Excel.Axis valueAxis = (Excel.Axis)chart.Axes(Excel.XlAxisType.xlValue, Excel.XlAxisGroup.xlPrimary);
+                  valueAxis.MinimumScaleIsAuto = true;
+                  valueAxis.MaximumScaleIsAuto = true;
+               }
+
+               currentRow = dataLast + 2;
+            }
+         }
+         catch (Exception ex)
+         {
+            ctx.ConsoleWriteLogLine("WriteResourceWallClockExcel EXCEPTION: " + ex.Message);
+         }
+         finally
+         {
+            activeBook.Save();
+            activeBook.Close();
+            excelApp.Quit();
+         }
+
+         ctx.ConsoleWriteLogLine("WriteResourceWallClockExcel: Complete");
+      }
+
       /// <summary>
       /// Writes a color legend showing what each state color means.
       /// </summary>
@@ -279,6 +435,67 @@ namespace OverView
          // Adjust column widths
          ((Excel.Range)worksheet.Columns[startCol, Type.Missing]).ColumnWidth = 3;
          ((Excel.Range)worksheet.Columns[startCol + 1, Type.Missing]).AutoFit();
+      }
+
+      /// <summary>
+      /// Orders the analytical worksheets left-to-right where present:
+      /// StateWallClock, then ResourceWallClock, then OverSummary. Missing sheets
+      /// are skipped; any other sheets stay to the right of these.
+      /// </summary>
+      public void OrderWorksheets()
+      {
+         string excelFileName = ctx.ExcelFileName;
+
+         Excel.Application excelApp = new Excel.Application
+         {
+            Visible = false,
+            DisplayAlerts = false
+         };
+         Excel.Workbook activeBook = excelApp.Workbooks.Open(excelFileName);
+
+         try
+         {
+            string[] desiredOrder = { "StateWallClock", "ResourceWallClock", "OverSummary" };
+            Excel._Worksheet previous = null;
+
+            foreach (string name in desiredOrder)
+            {
+               Excel._Worksheet sheet = null;
+               foreach (Excel._Worksheet candidate in activeBook.Sheets)
+               {
+                  if (candidate.Name == name)
+                  {
+                     sheet = candidate;
+                     break;
+                  }
+               }
+
+               if (sheet == null)
+               {
+                  continue;
+               }
+
+               if (previous == null)
+               {
+                  sheet.Move(Before: activeBook.Sheets[1]);
+               }
+               else
+               {
+                  sheet.Move(After: previous);
+               }
+               previous = sheet;
+            }
+         }
+         catch (Exception ex)
+         {
+            ctx.ConsoleWriteLogLine("OrderWorksheets EXCEPTION: " + ex.Message);
+         }
+         finally
+         {
+            activeBook.Save();
+            activeBook.Close();
+            excelApp.Quit();
+         }
       }
 
       #endregion
@@ -1168,6 +1385,16 @@ namespace OverView
 
                   /* deposit */
 
+                  case APLogType.APLOG_MEMORY:
+                     {
+                        base.ProcessRow(logLine);
+                        if (apLogLine is MemoryLine memoryLine)
+                        {
+                           APLOG_MEMORY(memoryLine);
+                        }
+                        break;
+                     }
+
                   default:
                      break;
                }
@@ -1309,6 +1536,73 @@ namespace OverView
          {
             ctx.ConsoleWriteLogLine("APLINE2 Exception : " + e.Message);
          }
+      }
+
+      protected void APLOG_MEMORY(MemoryLine memoryLine)
+      {
+         try
+         {
+            DataTable resourceTable = dTableSet.Tables["Resource"];
+
+            // A 'Date Time' line always starts a new snapshot row. Also start fresh if there
+            // is no pending row, or the pending row is stale (snapshot lines arrive within ms).
+            bool startNewRow = (memoryLine.metric == MemoryMetric.DateTimeCount) || (_pendingResourceRow == null);
+
+            if (!startNewRow)
+            {
+               DateTime pendingTime;
+               DateTime lineTime;
+               if (DateTime.TryParse((string)_pendingResourceRow["time"], out pendingTime) &&
+                   DateTime.TryParse(memoryLine.Timestamp, out lineTime) &&
+                   (lineTime - pendingTime).TotalSeconds > 5)
+               {
+                  startNewRow = true;
+               }
+            }
+
+            if (startNewRow)
+            {
+               _pendingResourceRow = resourceTable.Rows.Add();
+               _pendingResourceRow["file"] = memoryLine.LogFile;
+               _pendingResourceRow["time"] = memoryLine.Timestamp;
+               _pendingResourceRow["count"] = string.Empty;
+               _pendingResourceRow["memoryMB"] = string.Empty;
+               _pendingResourceRow["vmSizeMB"] = string.Empty;
+               _pendingResourceRow["privateSizeMB"] = string.Empty;
+               _pendingResourceRow["handles"] = string.Empty;
+            }
+
+            switch (memoryLine.metric)
+            {
+               case MemoryMetric.DateTimeCount:
+                  _pendingResourceRow["count"] = memoryLine.value.ToString();
+                  break;
+               case MemoryMetric.Memory:
+                  _pendingResourceRow["memoryMB"] = BytesToMB(memoryLine.value);
+                  break;
+               case MemoryMetric.VMSize:
+                  _pendingResourceRow["vmSizeMB"] = BytesToMB(memoryLine.value);
+                  break;
+               case MemoryMetric.PrivateSize:
+                  _pendingResourceRow["privateSizeMB"] = BytesToMB(memoryLine.value);
+                  break;
+               case MemoryMetric.HandleCount:
+                  _pendingResourceRow["handles"] = memoryLine.value.ToString();
+                  break;
+            }
+
+            resourceTable.AcceptChanges();
+         }
+         catch (Exception e)
+         {
+            ctx.ConsoleWriteLogLine("APLOG_MEMORY Exception : " + e.Message);
+         }
+      }
+
+      private static string BytesToMB(long bytes)
+      {
+         double megabytes = bytes / (1024.0 * 1024.0);
+         return megabytes.ToString("F1");
       }
    }
 }

--- a/src/OverView/OverView.cs
+++ b/src/OverView/OverView.cs
@@ -1,4 +1,4 @@
-using Contract;
+﻿using Contract;
 using Impl;
 using System.ComponentModel.Composition;
 using System.Data;
@@ -12,6 +12,8 @@ namespace OverView
       /// The analyzer for calculating ATM state segments.
       /// </summary>
       private StateWallClockAnalyzer _wallClockAnalyzer;
+
+      private ResourceWallClockAnalyzer _resourceAnalyzer;
 
       /// <summary>
       /// Reference to the OverTable for analysis phase.
@@ -50,6 +52,8 @@ namespace OverView
 
          // Initialize the analyzer
          _wallClockAnalyzer = new StateWallClockAnalyzer();
+
+         _resourceAnalyzer = new ResourceWallClockAnalyzer();
 
          ctx.LogWriteLine("PreAnalyze: Data loaded for analysis");
       }
@@ -96,6 +100,14 @@ namespace OverView
                }
             }
          }
+
+         // Resource wall-clock: bucket snapshot rows into per-day 15-minute grids
+         DataTable resourceTable = _analyzeTable.GetResourceTable();
+         if (resourceTable != null)
+         {
+            _resourceAnalyzer.Analyze(resourceTable);
+            ctx.LogWriteLine($"Analyze: Generated {_resourceAnalyzer.Results.Count} resource day grids");
+         }
       }
 
       /// <summary>
@@ -141,6 +153,16 @@ namespace OverView
             ctx.ConsoleWriteLogLine("WriteExcel: Writing StateWallClock worksheet with wall clock charts");
             overTable.WriteStateWallClockExcel(_wallClockAnalyzer.Results);
          }
+
+         // Resource snapshots: one auto-scaled line chart per metric
+         if (_resourceAnalyzer?.Results != null && _resourceAnalyzer.Results.Count > 0)
+         {
+            ctx.ConsoleWriteLogLine("WriteExcel: Writing ResourceWallClock worksheet");
+            overTable.WriteResourceWallClockExcel(_resourceAnalyzer.Results);
+         }
+
+         // Order analytical worksheets left-to-right where present
+         overTable.OrderWorksheets();
 
          ctx.ConsoleWriteLogLine("End WriteExcel: " + viewName);
       }

--- a/src/OverView/OverView.csproj
+++ b/src/OverView/OverView.csproj
@@ -53,6 +53,7 @@
       <DependentUpon>OverView.xsd</DependentUpon>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ResourceWallClockAnalyzer.cs" />
     <Compile Include="StateWallClockAnalyzer.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -97,6 +98,7 @@
   <ItemGroup>
     <WCFMetadata Include="Connected Services\" />
   </ItemGroup>
-  <ItemGroup></ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/OverView/OverView.xsd
+++ b/src/OverView/OverView.xsd
@@ -31,6 +31,19 @@
             </xs:sequence>
           </xs:complexType>
         </xs:element>
+        <xs:element name="Resource">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="file" type="xs:string" minOccurs="0" />
+              <xs:element name="time" type="xs:string" minOccurs="0" />
+              <xs:element name="count" type="xs:string" minOccurs="0" />
+              <xs:element name="memoryMB" type="xs:string" minOccurs="0" />
+              <xs:element name="vmSizeMB" type="xs:string" minOccurs="0" />
+              <xs:element name="privateSizeMB" type="xs:string" minOccurs="0" />
+              <xs:element name="handles" type="xs:string" minOccurs="0" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>		
       </xs:choice>
     </xs:complexType>
   </xs:element>

--- a/src/OverView/ResourceWallClockAnalyzer.cs
+++ b/src/OverView/ResourceWallClockAnalyzer.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Globalization;
+using System.Linq;
+
+namespace OverView
+{
+   /// <summary>
+   /// One day's resource metrics bucketed into 96 fifteen-minute slots
+   /// (00:00 .. 23:45). A null slot means "no data yet" — slots before the first
+   /// sample of the day stay null (a gap on the chart); from the first sample
+   /// onward each metric is carried forward until the next sample.
+   /// </summary>
+   public class ResourceDaySlots
+   {
+      public const int SlotCount = 96;   // 24h * 4 slots/hour
+
+      public DateTime Date { get; set; }
+      public double?[] Memory { get; } = new double?[SlotCount];
+      public double?[] VmSize { get; } = new double?[SlotCount];
+      public double?[] Private { get; } = new double?[SlotCount];
+      public double?[] Handles { get; } = new double?[SlotCount];
+
+      /// <summary>Slot label, e.g. "13:15".</summary>
+      public static string SlotLabel(int slot)
+      {
+         return TimeSpan.FromMinutes(slot * 15).ToString(@"hh\:mm");
+      }
+   }
+
+   /// <summary>
+   /// Buckets the raw Resource snapshot rows into per-day, 96-slot grids: each
+   /// sample is dropped into its NEAREST 15-minute slot, then values are filled
+   /// forward until the next sample is found. Mirrors the per-day grouping that
+   /// StateWallClockAnalyzer uses so the two wall-clock views behave the same.
+   /// </summary>
+   public class ResourceWallClockAnalyzer
+   {
+      public List<ResourceDaySlots> Results { get; private set; } = new List<ResourceDaySlots>();
+
+      public void Analyze(DataTable resourceTable)
+      {
+         Results = new List<ResourceDaySlots>();
+         if (resourceTable == null || resourceTable.Rows.Count == 0)
+         {
+            return;
+         }
+
+         // Parse rows, skipping anything without a usable timestamp.
+         List<Sample> samples = new List<Sample>();
+         foreach (DataRow row in resourceTable.Rows)
+         {
+            DateTime ts;
+            if (!TryParseTime(row, out ts))
+            {
+               continue;
+            }
+
+            Sample s = new Sample();
+            s.Time = ts;
+            s.Memory = ParseDouble(row, "memoryMB");
+            s.VmSize = ParseDouble(row, "vmSizeMB");
+            s.Private = ParseDouble(row, "privateSizeMB");
+            s.Handles = ParseDouble(row, "handles");
+            samples.Add(s);
+         }
+
+         if (samples.Count == 0)
+         {
+            return;
+         }
+
+         // One grid per calendar day, in date order.
+         foreach (IGrouping<DateTime, Sample> dayGroup in samples
+                     .GroupBy(s => s.Time.Date)
+                     .OrderBy(g => g.Key))
+         {
+            ResourceDaySlots day = new ResourceDaySlots();
+            day.Date = dayGroup.Key;
+
+            // Drop each sample into its nearest slot; a later sample in the same
+            // slot overwrites an earlier one.
+            foreach (Sample s in dayGroup.OrderBy(s => s.Time))
+            {
+               int slot = NearestSlot(s.Time);
+               if (s.Memory.HasValue) { day.Memory[slot] = s.Memory; }
+               if (s.VmSize.HasValue) { day.VmSize[slot] = s.VmSize; }
+               if (s.Private.HasValue) { day.Private[slot] = s.Private; }
+               if (s.Handles.HasValue) { day.Handles[slot] = s.Handles; }
+            }
+
+            FillForward(day.Memory);
+            FillForward(day.VmSize);
+            FillForward(day.Private);
+            FillForward(day.Handles);
+
+            Results.Add(day);
+         }
+      }
+
+      /// <summary>Nearest 15-minute slot (0..95) for a time of day.</summary>
+      private static int NearestSlot(DateTime t)
+      {
+         double minutes = t.TimeOfDay.TotalMinutes;
+         int slot = (int)Math.Round(minutes / 15.0, MidpointRounding.AwayFromZero);
+         if (slot < 0)
+         {
+            slot = 0;
+         }
+         if (slot > ResourceDaySlots.SlotCount - 1)
+         {
+            slot = ResourceDaySlots.SlotCount - 1;
+         }
+         return slot;
+      }
+
+      /// <summary>Carry the last non-null value forward into later empty slots.</summary>
+      private static void FillForward(double?[] series)
+      {
+         double? last = null;
+         for (int i = 0; i < series.Length; i++)
+         {
+            if (series[i].HasValue)
+            {
+               last = series[i];
+            }
+            else if (last.HasValue)
+            {
+               series[i] = last;
+            }
+         }
+      }
+
+      private static bool TryParseTime(DataRow row, out DateTime ts)
+      {
+         ts = DateTime.MinValue;
+         if (!row.Table.Columns.Contains("time"))
+         {
+            return false;
+         }
+
+         string raw = row["time"] as string;
+         if (string.IsNullOrWhiteSpace(raw))
+         {
+            return false;
+         }
+
+         // Resource 'time' is the APLine timestamp form: "yyyy-MM-dd HH:mm:ss.fff"
+         return DateTime.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.None, out ts);
+      }
+
+      private static double? ParseDouble(DataRow row, string column)
+      {
+         if (!row.Table.Columns.Contains(column))
+         {
+            return null;
+         }
+
+         string raw = row[column] as string;
+         if (string.IsNullOrWhiteSpace(raw))
+         {
+            return null;
+         }
+
+         double value;
+         if (double.TryParse(raw, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
+         {
+            return value;
+         }
+         return null;
+      }
+
+      private class Sample
+      {
+         public DateTime Time;
+         public double? Memory;
+         public double? VmSize;
+         public double? Private;
+         public double? Handles;
+      }
+   }
+}


### PR DESCRIPTION
Parse the periodic resource-usage snapshot lines XTM writes to the APLog (working set memory, VM size, private bytes, handle count) and surface them as per-day line charts so support can spot an ATM heading toward a 32-bit address-space exhaustion crash from the logs, before it goes out of service.

Each snapshot is a group of five consecutive lines sharing a timestamp; they are accumulated into one row, then bucketed per calendar day into a fixed 96-slot (15-minute) grid. Samples fit to the nearest slot and carry forward until the next sample, giving every day an identically-sized 00:00-23:45 x-axis that is directly comparable day to day.

New files:
- MemoryLine.cs: APLine subclass + MemoryMetric enum. Sub-factory classifies the five snapshot formats and parses the value off the last ':' (correctly skipping the time-of-day colons on the Date/Time line).
- ResourceWallClockAnalyzer.cs: ResourceDaySlots (96-slot per-metric grid) + analyzer that groups Resource rows by day, fits each sample to its nearest slot, and fills forward. Mirrors StateWallClockAnalyzer.
- MemoryLineTests.cs: covers the five formats, the count-colon trap, comma-separated byte parsing, timestamp extraction, and end-to-end routing through APLine.Factory.

Changed:
- APLine.cs: route resource lines to MemoryLine.Factory with a null-guarded fall-through so non-resource "Memory" lines pass on.
- OverView.xsd: add the Resource DataTable (file, time, count, memoryMB, vmSizeMB, privateSizeMB, handles).
- OverTable.cs: accumulate each snapshot group into a Resource row (pending-row + 5s staleness guard), bytes->MB; GetResourceTable accessor; WriteResourceWallClockExcel writes the ResourceWallClock worksheet (four 2:1 line charts per day, auto-scaled, with a dashed 4 GB reference line on the VM Size and Private Size charts); add OrderWorksheets to place StateWallClock, ResourceWallClock, OverSummary left-to-right where present.
- OverView.cs: build/run the resource analyzer in PreAnalyze/Analyze, write the worksheet and order the tabs in WriteExcel.

The raw Resource worksheet is still emitted by WriteExcelFile; the ResourceWallClock worksheet adds the per-day visualization beside it. Series line styling uses Series.Border (Excel interop) rather than Series.Format.Line, which requires the office PIA this project doesn't reference.