### PR TITLE
fix: route message 23 to Atm2Host23 and decode Encryptor Init Data

### DIFF
--- a/src/APLine/NDC/Atm2Host/Atm2Host.cs
+++ b/src/APLine/NDC/Atm2Host/Atm2Host.cs
@@ -32,7 +32,7 @@ namespace LogLineHandler
                return new Atm2Host22(logFileHandler, logLine, APLogType.NDC_ATM2HOST22);
 
             if (result2.success && result2.field.StartsWith("23"))
-               return new Atm2Host22(logFileHandler, logLine, APLogType.NDC_ATM2HOST23);
+               return new Atm2Host23(logFileHandler, logLine, APLogType.NDC_ATM2HOST23);
 
             if (result2.success && result2.field.StartsWith("51"))
                return new Atm2Host51(logFileHandler, logLine, APLogType.NDC_ATM2HOST51);

--- a/src/APLine/NDC/Atm2Host/Atm2Host23.cs
+++ b/src/APLine/NDC/Atm2Host/Atm2Host23.cs
@@ -19,13 +19,131 @@ namespace LogLineHandler
 
          try
          {
+            // Field b and c - Message Class / Sub-Class - 23
+            (bool success, string field, string subMessage) result = GetNextFieldBySeparator(ndcmsg);
+            if (!result.success)
+               return;
+
+            english = "Solicited Status to Host (Encryptor Initialisation Data), ";
+
+            // Field d - LUNO
+            result = NDC.GetNextFieldBySeparator(result.subMessage);
+            if (!result.success)
+               return;
+
+            english = english + String.Format("LUNO '{0}', ", result.field);
+
+            // Field - none - two FS back to back
+            result = NDC.GetNextFieldBySeparator(result.subMessage);
+            if (!result.success)
+               return;
+
+            // Field e - Information Identifier
+            result = NDC.GetNextFieldBySeparator(result.subMessage);
+            if (!result.success || result.field.Length == 0)
+               return;
+
+            string infoId = result.field.Substring(0, 1);
+            english = english + String.Format("Information Identifier : {0}, ", InfoIdentifierInEnglish(infoId));
+
+            // Field f - Encryptor Information (format depends on the identifier).
+            // Note: GetNextFieldBySeparator returns success=false for the LAST
+            // field (no trailing separator) but still returns the field text,
+            // so guard on field content, not success.
+            result = NDC.GetNextFieldBySeparator(result.subMessage);
+            if (result.field.Length > 0)
+            {
+               if (infoId == "6")
+               {
+                  // Key Entry Mode - a single meaningful character
+                  english = english + String.Format("Key Entry Mode : {0}, ", KeyEntryModeInEnglish(result.field.Substring(0, 1)));
+               }
+               else if (infoId == "1" || infoId == "2")
+               {
+                  // EPP serial/public key signatures - long base-94 blobs, not useful in a summary
+                  english = english + "Signature data present, ";
+               }
+               else
+               {
+                  // KVVs, key status, capabilities, etc. - short and diagnostically useful
+                  english = english + String.Format("Data : {0}, ", result.field);
+               }
+            }
          }
          catch (Exception e)
          {
             this.parentHandler.ctx.ConsoleWriteLogLine(String.Format("{0} Unexpected parse in message : {1}, {2}", myName, ndcmsg, e.Message));
          }
 
-         return ;
+         return;
+      }
+
+      // see p 9-66 - Encryptor Initialisation Data, Information Identifier (field e)
+      private string InfoIdentifierInEnglish(string infoId)
+      {
+         if (infoId == "1")
+         {
+            return "1 (EPP Serial Number and Signature)";
+         }
+         if (infoId == "2")
+         {
+            return "2 (EPP Public Key and Signature)";
+         }
+         if (infoId == "3")
+         {
+            return "3 (New Key Verification Value for key just loaded or reactivated)";
+         }
+         if (infoId == "4")
+         {
+            return "4 (Keys Status)";
+         }
+         if (infoId == "5")
+         {
+            return "5 (Key Loaded)";
+         }
+         if (infoId == "6")
+         {
+            return "6 (Key Entry Mode)";
+         }
+         if (infoId == "7")
+         {
+            return "7 (RSA encryption KVV)";
+         }
+         if (infoId == "9")
+         {
+            return "9 (ATM random number)";
+         }
+         if (infoId == "B")
+         {
+            return "B (Encryptor capabilities and state)";
+         }
+         if (infoId == "C")
+         {
+            return "C (Key deleted)";
+         }
+         return infoId;
+      }
+
+      // see p 9-67 - Key Entry Mode, valid when Information Identifier = '6'
+      private string KeyEntryModeInEnglish(string mode)
+      {
+         if (mode == "1")
+         {
+            return "1 (Single length without XOR)";
+         }
+         if (mode == "2")
+         {
+            return "2 (Single length with XOR)";
+         }
+         if (mode == "3")
+         {
+            return "3 (Double length with XOR)";
+         }
+         if (mode == "4")
+         {
+            return "4 (Double length, restricted)";
+         }
+         return mode;
       }
    }
 }

--- a/src/APLogLineTests/APLogHandler_IdentifyLines_NDC_Tests.cs
+++ b/src/APLogLineTests/APLogHandler_IdentifyLines_NDC_Tests.cs
@@ -464,5 +464,18 @@ namespace APLogLineTests
          StringAssert.Contains(apLine.english, "Notes retracted after Present time-out");
          StringAssert.Contains(apLine.english, "type1=20");
       }
+
+      [TestMethod]
+      public void Atm2Host23_EncryptorKVV()
+      {
+         ILogFileHandler logFileHandler = new APLogHandler(new CreateTextStreamReaderMock(), ParseType.AP, APLine.Factory);
+         ILogLine logLine = logFileHandler.IdentifyLine(samples_ndc.ATM2HOST23_6);
+         Assert.IsTrue(logLine is Atm2Host23, String.Format("logLine is not Atm2Host23"));
+
+         Atm2Host23 apLine = (Atm2Host23)logLine;
+         StringAssert.Contains(apLine.english, "Encryptor Initialisation Data", String.Format("apLine does not contain Encryptor Initialisation Data"));
+         StringAssert.Contains(apLine.english, "New Key Verification Value", String.Format("apLine does not contain New Key Verification Value"));
+         StringAssert.Contains(apLine.english, "5783FD", String.Format("apLine does not contain 5783FD"));
+      }
    }
 }

--- a/src/APSamplesTests/samples_ndc.cs
+++ b/src/APSamplesTests/samples_ndc.cs
@@ -96,6 +96,9 @@ namespace Samples
       public const string ATM2HOST23_5 =
          @"[2023-03-30 03:08:19-477][0][][Log                 ][Send                ][SEND]ATM2HOST: 23050401DFDD058B2B000000000000";
 
+      public const string ATM2HOST23_6 =
+         @"  INFO [2026-06-10 03:02:40-950] [v02.02.06.04] [Log.Send] [TID:3] ATM2HOST: 2305035783FD";
+
       public const string ATM2HOST51_1 =
          @"[2023-03-17 01:34:18-209][0][][Log                 ][Send                ][SEND]ATM2HOST: 61015920230317013418130566130604038";
 


### PR DESCRIPTION
Atm2Host.Factory constructed Atm2Host22 for message class 23, so every Encryptor Initialisation Data message (class 2, sub-class 3) was decoded with the wrong field layout. Routes to Atm2Host23 and fills in its previously-empty Initialize() with the Information Identifier decode (Advance NDC Reference Manual p 9-66) plus a payload echo for the short diagnostic values (KVVs, key status, entry mode). Base-94 signature blobs (identifiers 1/2) are noted but not dumped.

The payload is the message's final field; GetNextFieldBySeparator returns success=false for the last field (no trailing separator) while still returning the field text, so the f-field guard checks field content rather than success.

Verified against real key-verification samples (identifier 3, 6-char KVV) from NHSWS-17487 logs.