### PR TITLE
fix: guard amount parse in transaction request (Atm2Host11)

### DIFF
--- a/src/APLine/NDC/Atm2Host/Atm2Host11.cs
+++ b/src/APLine/NDC/Atm2Host/Atm2Host11.cs
@@ -81,13 +81,13 @@ namespace LogLineHandler
 
             if (!string.IsNullOrEmpty(result.field))
             {
-               if (int.Parse(result.field) == 0)
+               // Amount Entry Field is 8 or 12 bytes, right-justified zero-filled
+               // (Table 9-1, field k). int.Parse overflows on the 12-byte variant
+               // and throws on any non-numeric fill; decimal.TryParse handles both.
+               decimal amountValue;
+               if (decimal.TryParse(result.field, out amountValue) && amountValue > 0)
                {
-                  //English = English + String.Format(" amount $0.00, ");
-               }
-               else
-               {
-                  amount = (Convert.ToDecimal(result.field) / 100).ToString();
+                  amount = (amountValue / 100).ToString("0.00");
                   english = english + String.Format(" amount ${0}, ", amount);
                }
             }


### PR DESCRIPTION
The Amount Entry Field is 8 or 12 bytes (Table 9-1, field k). int.Parse overflowed on the 12-byte variant and threw on non-numeric fill, silently aborting the rest of the decode via the catch. Uses decimal.TryParse and formats to 2dp for consistent output ($500.00 not $500).