### PR TITLE
MoniView perf: skip cross-handler file reads + fix O(n^2) per-row AcceptChanges in MV tables

### DIFF
--- a/src/BaseView/BaseView.cs
+++ b/src/BaseView/BaseView.cs
@@ -72,12 +72,39 @@ namespace Impl
          return;
       }
 
+      /// <summary>
+      /// Interim MoniView performance guard. A view's Process runs once for every LogFileHandler
+      /// that shares this view's ParseType. Usually that is exactly one handler, but MoniView has
+      /// two handlers under ParseType.MV - MVLogHandler (MoniViewServerLog*.txt) and TcpLogHandler
+      /// (TcpTrace_*.txt). A view that only consumes one of the two file families would otherwise
+      /// still open and parse the other family's files (thousands of TcpTrace files on a fleet
+      /// capture) and discard every line in ProcessRow. Overriding this lets a view decline a
+      /// handler up front, before the read loop, so it never touches files it cannot use.
+      ///
+      /// Default: accept every handler that matched this view's ParseType - unchanged behaviour for
+      /// all non-MoniView views.
+      /// </summary>
+      /// <param name="handler">the handler about to be processed (ctx.activeHandler)</param>
+      /// <returns>true to run the read loop for this handler; false to skip it</returns>
+      protected virtual bool HandlesActiveHandler(ILogFileHandler handler)
+      {
+         return true;
+      }
+
       /// <summary>Call to process the datatable (merge of all log lines)</summary>
       /// <returns>void</returns>
       public virtual void Process(IContext ctx)
       {
          ctx.LogWriteLine("BaseView.------------------------------------------------");
          ctx.LogWriteLine("BaseView.Process: " + viewName);
+
+         // MoniView perf guard: don't read files this view can't consume (e.g. server-log views
+         // skipping thousands of TcpTrace_*.txt captures, and vice-versa). No-op for other views.
+         if (!HandlesActiveHandler(ctx.activeHandler))
+         {
+            ctx.ConsoleWriteLogLine(String.Format("BaseView.Process: {0} does not consume {1} files - skipping", viewName, ctx.activeHandler.Name));
+            return;
+         }
 
          // For each file found by this log handler...
          foreach (string fileName in ctx.activeHandler.FilesFound)

--- a/src/MVErrorsView/MVErrorsTable.cs
+++ b/src/MVErrorsView/MVErrorsTable.cs
@@ -58,13 +58,31 @@ namespace MVErrorsView
             dataRow["kind"] = mvLine.Kind;
             dataRow["comment"] = mvLine.Comment;
             dataRow["detail"] = Truncate(mvLine.Detail, SENSIBLE_EXCEL_CELL_DATA_LENGTH);
-
-            dTableSet.Tables[TABLE_NAME].AcceptChanges();
          }
          catch (Exception e)
          {
             ctx.ConsoleWriteLogLine("MVErrorsTable.AddErrorRow Exception : " + e.Message);
          }
+      }
+
+      /// <summary>
+      /// Commit all added rows once, at the end. AcceptChanges() walks the whole table, so calling
+      /// it per row (as AddErrorRow used to) makes a growing table O(n^2) - the MoniView fleet-scale
+      /// slowdown. One call here is equivalent: WriteXml serializes current row values regardless of
+      /// RowState.
+      /// </summary>
+      public override void PostProcess()
+      {
+         try
+         {
+            dTableSet.Tables[TABLE_NAME].AcceptChanges();
+         }
+         catch (Exception e)
+         {
+            ctx.ConsoleWriteLogLine("MVErrorsTable.PostProcess Exception : " + e.Message);
+         }
+
+         base.PostProcess();
       }
 
       private string Truncate(string value, int max)

--- a/src/MVErrorsView/MVErrorsView.cs
+++ b/src/MVErrorsView/MVErrorsView.cs
@@ -23,5 +23,15 @@ namespace MVErrorsView
          errorsTable.ReadXmlFile();
          return errorsTable;
       }
+
+      /// <summary>
+      /// Server-log view: only consume MoniViewServerLog*.txt (MVLogHandler). Skip the
+      /// TcpTrace_*.txt captures (TcpLogHandler) - a fleet capture has thousands and every line
+      /// would be discarded in ProcessRow. See BaseView.HandlesActiveHandler.
+      /// </summary>
+      protected override bool HandlesActiveHandler(ILogFileHandler handler)
+      {
+         return handler != null && handler.Name == "MVLogFileHandler";
+      }
    }
 }

--- a/src/MVOutboundView/MVOutboundView.cs
+++ b/src/MVOutboundView/MVOutboundView.cs
@@ -21,5 +21,15 @@ namespace MVOutboundView
          outboundTable.ReadXmlFile();
          return outboundTable;
       }
+
+      /// <summary>
+      /// Server-log view: only consume MoniViewServerLog*.txt (MVLogHandler). Skip the
+      /// TcpTrace_*.txt captures (TcpLogHandler) - a fleet capture has thousands and every line
+      /// would be discarded in ProcessRow. See BaseView.HandlesActiveHandler.
+      /// </summary>
+      protected override bool HandlesActiveHandler(ILogFileHandler handler)
+      {
+         return handler != null && handler.Name == "MVLogFileHandler";
+      }
    }
 }

--- a/src/MVRosterView/MVRosterView.cs
+++ b/src/MVRosterView/MVRosterView.cs
@@ -23,5 +23,15 @@ namespace MVRosterView
          rosterTable.ReadXmlFile();
          return rosterTable;
       }
+
+      /// <summary>
+      /// Server-log view: only consume MoniViewServerLog*.txt (MVLogHandler). Skip the
+      /// TcpTrace_*.txt captures (TcpLogHandler) - a fleet capture has thousands and every line
+      /// would be discarded in ProcessRow. See BaseView.HandlesActiveHandler.
+      /// </summary>
+      protected override bool HandlesActiveHandler(ILogFileHandler handler)
+      {
+         return handler != null && handler.Name == "MVLogFileHandler";
+      }
    }
 }

--- a/src/WireTraceView/WireTraceTable.cs
+++ b/src/WireTraceView/WireTraceTable.cs
@@ -92,7 +92,9 @@ namespace WireTraceView
             row["encidx"] = tcp.EncIndexHex;
             row["frameok"] = (tcp.MsgType == TcpMsgType.Data) ? (tcp.FrameOk ? "yes" : "NO") : "";
             row["comment"] = RowComment(tcp);
-            dTableSet.Tables[WIRE].AcceptChanges();
+            // NOTE: AcceptChanges() is deliberately NOT called here. It walks the whole table, so
+            // committing per frame made this O(n^2) - catastrophic at fleet scale (one row per frame
+            // over 2GB of TcpTrace). Both sheets are committed once in PostProcess instead.
          }
          catch (Exception e)
          {
@@ -211,8 +213,11 @@ namespace WireTraceView
                row["avgsize"] = avgSize.ToString();
                row["firstseen"] = agg.First;
                row["comment"] = SummaryComment(agg, cleanPct);
-               dTableSet.Tables[SUMMARY].AcceptChanges();
             }
+
+            // Commit both sheets once (per-frame AcceptChanges was O(n^2) - see AddWireRow).
+            dTableSet.Tables[WIRE].AcceptChanges();
+            dTableSet.Tables[SUMMARY].AcceptChanges();
          }
          catch (Exception e)
          {

--- a/src/WireTraceView/WireTraceView.cs
+++ b/src/WireTraceView/WireTraceView.cs
@@ -19,5 +19,15 @@ namespace WireTraceView
          wireTable.ReadXmlFile();
          return wireTable;
       }
+
+      /// <summary>
+      /// WireTrace only consumes the TcpTrace_*.txt captures (TcpLogHandler). Skip the
+      /// MoniViewServerLog*.txt files (MVLogHandler) - it discards every server-log line anyway.
+      /// See BaseView.HandlesActiveHandler.
+      /// </summary>
+      protected override bool HandlesActiveHandler(ILogFileHandler handler)
+      {
+         return handler != null && handler.Name == "TcpLogFileHandler";
+      }
    }
 }


### PR DESCRIPTION
…